### PR TITLE
Added option to have an arbitrarily oriented cutting plane

### DIFF
--- a/glue_vispy_viewers/common/qt/limits.ui
+++ b/glue_vispy_viewers/common/qt/limits.ui
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>276</width>
+    <height>320</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Limits</string>
+  </property>
+  <layout class="QGridLayout" name="limits_grid">
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>10</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>10</number>
+   </property>
+   <property name="horizontalSpacing">
+    <number>8</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>5</number>
+   </property>
+   <item row="0" column="0" colspan="4">
+    <widget class="QLabel" name="label_x_axis">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>x axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_x_minmax">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="valuetext_x_min"/>
+   </item>
+   <item row="1" column="2">
+    <widget class="QToolButton" name="button_flip_x">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QLineEdit" name="valuetext_x_max"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_x_stretch">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QSlider" name="value_x_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QLineEdit" name="valuetext_x_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="4">
+    <widget class="QLabel" name="label_y_axis">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>y axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_y_minmax">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="valuetext_y_min"/>
+   </item>
+   <item row="4" column="2">
+    <widget class="QToolButton" name="button_flip_y">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="QLineEdit" name="valuetext_y_max"/>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_y_stretch">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="2">
+    <widget class="QSlider" name="value_y_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="3">
+    <widget class="QLineEdit" name="valuetext_y_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="4">
+    <widget class="QLabel" name="label_z_axis">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>z axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_z_minmax">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="valuetext_z_min"/>
+   </item>
+   <item row="7" column="2">
+    <widget class="QToolButton" name="button_flip_z">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="3">
+    <widget class="QLineEdit" name="valuetext_z_max"/>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_z_stretch">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1" colspan="2">
+    <widget class="QSlider" name="value_z_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="3">
+    <widget class="QLineEdit" name="valuetext_z_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/glue_vispy_viewers/common/qt/viewer_options.py
+++ b/glue_vispy_viewers/common/qt/viewer_options.py
@@ -14,6 +14,13 @@ __all__ = ["VispyOptionsWidget"]
 
 
 class VispyOptionsWidget(QtWidgets.QWidget):
+    """Tabbed viewer-options widget shared by the scatter and volume viewers.
+
+    "General" holds the reference data, axis attributes, resolution, slices
+    and the display toggles. "Limits" holds the per-axis min/max, flip and
+    stretch controls. The volume viewer adds a "Cutting plane" tab on top
+    (see ``VolumeOptionsWidget``).
+    """
 
     def __init__(self, viewer_state=None, session=None, parent=None):
 
@@ -21,15 +28,19 @@ class VispyOptionsWidget(QtWidgets.QWidget):
 
         self._data_collection = session.data_collection
 
-        self.ui = load_ui('viewer_options.ui', self,
-                          directory=os.path.dirname(__file__))
+        self._tabs = QtWidgets.QTabWidget(self)
+        outer = QtWidgets.QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.addWidget(self._tabs)
 
-        connect_kwargs = {'value_x_stretch': dict(value_range=(0.1, 10), log=True),
-                          'value_y_stretch': dict(value_range=(0.1, 10), log=True),
-                          'value_z_stretch': dict(value_range=(0.1, 10), log=True),
-                          'valuetext_x_stretch': dict(fmt='{:6.2f}'),
-                          'valuetext_y_stretch': dict(fmt='{:6.2f}'),
-                          'valuetext_z_stretch': dict(fmt='{:6.2f}')}
+        directory = os.path.dirname(__file__)
+        self.general = QtWidgets.QWidget()
+        self.ui = load_ui('viewer_options.ui', self.general, directory=directory)
+        self._tabs.addTab(self.general, 'General')
+
+        self.limits = QtWidgets.QWidget()
+        self.limits_ui = load_ui('limits.ui', self.limits, directory=directory)
+        self._tabs.addTab(self.limits, 'Limits')
 
         if not isinstance(viewer_state, Vispy3DScatterViewerState):
             self.ui.bool_clip_data.hide()
@@ -52,4 +63,13 @@ class VispyOptionsWidget(QtWidgets.QWidget):
         self.ui.label_line_width.hide()
         self.ui.value_line_width.hide()
 
-        self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui, connect_kwargs)
+        stretch_kwargs = {'value_x_stretch': dict(value_range=(0.1, 10), log=True),
+                          'value_y_stretch': dict(value_range=(0.1, 10), log=True),
+                          'value_z_stretch': dict(value_range=(0.1, 10), log=True),
+                          'valuetext_x_stretch': dict(fmt='{:6.2f}'),
+                          'valuetext_y_stretch': dict(fmt='{:6.2f}'),
+                          'valuetext_z_stretch': dict(fmt='{:6.2f}')}
+
+        self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui)
+        self._connections_limits = autoconnect_callbacks_to_qt(
+            viewer_state, self.limits_ui, stretch_kwargs)

--- a/glue_vispy_viewers/common/qt/viewer_options.ui
+++ b/glue_vispy_viewers/common/qt/viewer_options.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>276</width>
-    <height>443</height>
+    <height>360</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,45 +29,7 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <item row="11" column="2">
-    <widget class="QLabel" name="label_resolution">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>resolution:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>y axis</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="2">
+   <item row="0" column="0">
     <widget class="QLabel" name="label_reference_data">
      <property name="font">
       <font>
@@ -79,25 +41,92 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="3">
-    <widget class="QLineEdit" name="valuetext_y_min"/>
-   </item>
-   <item row="1" column="4">
-    <widget class="QToolButton" name="button_flip_x">
-     <property name="font">
-      <font>
-       <pointsize>14</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">padding: 0px</string>
-     </property>
-     <property name="text">
-      <string>⇄</string>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="combosel_reference_data">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
     </widget>
    </item>
-   <item row="11" column="2">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_x_axis">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>x axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="combosel_x_att">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_y_axis">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>y axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="combosel_y_att">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_z_axis">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>z axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="combosel_z_att">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <widget class="QLabel" name="label_resolution">
      <property name="font">
       <font>
@@ -109,52 +138,25 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="combosel_resolution">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
     </widget>
    </item>
-   <item row="8" column="5">
-    <widget class="QLineEdit" name="valuetext_z_max"/>
+   <item row="5" column="0" colspan="2">
+    <layout class="QVBoxLayout" name="layout_slices"/>
    </item>
-   <item row="6" column="5">
-    <widget class="QLineEdit" name="valuetext_y_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="2" colspan="4">
+   <item row="6" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="0" colspan="2">
-      <widget class="QCheckBox" name="bool_downsample">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Downsample when panning</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QCheckBox" name="bool_native_aspect">
        <property name="text">
         <string>Native aspect ratio</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="bool_perspective_view">
-       <property name="text">
-        <string>Perspective</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -188,10 +190,13 @@
        </item>
       </layout>
      </item>
-     <item row="3" column="0" colspan="2">
-      <widget class="QCheckBox" name="bool_clip_data">
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="bool_perspective_view">
        <property name="text">
-        <string>Restrict to bounding box</string>
+        <string>Perspective</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -205,37 +210,26 @@
        </property>
       </widget>
      </item>
+     <item row="2" column="0" colspan="2">
+      <widget class="QCheckBox" name="bool_downsample">
+       <property name="text">
+        <string>Downsample when panning</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QCheckBox" name="bool_clip_data">
+       <property name="text">
+        <string>Restrict to bounding box</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
-   <item row="8" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3" colspan="3">
-    <widget class="QComboBox" name="combosel_x_att">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3" colspan="3">
-    <widget class="QComboBox" name="combosel_y_att">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="2">
+   <item row="7" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -248,186 +242,8 @@
      </property>
     </spacer>
    </item>
-   <item row="6" column="3" colspan="2">
-    <widget class="QSlider" name="value_y_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>y axis</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="4">
-    <widget class="QToolButton" name="button_flip_z">
-     <property name="font">
-      <font>
-       <pointsize>14</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">padding: 0px</string>
-     </property>
-     <property name="text">
-      <string>⇄</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="3">
-    <widget class="QLineEdit" name="valuetext_z_min"/>
-   </item>
-   <item row="2" column="5">
-    <widget class="QLineEdit" name="valuetext_x_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="3" colspan="3">
-    <widget class="QComboBox" name="combosel_z_att">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="3" colspan="3">
-    <widget class="QComboBox" name="combosel_reference_data"/>
-   </item>
-   <item row="9" column="5">
-    <widget class="QLineEdit" name="valuetext_z_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="4">
-    <widget class="QToolButton" name="button_flip_y">
-     <property name="font">
-      <font>
-       <pointsize>14</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">padding: 0px</string>
-     </property>
-     <property name="text">
-      <string>⇄</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="3" colspan="2">
-    <widget class="QSlider" name="value_z_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>x axis</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="3" colspan="2">
-    <widget class="QComboBox" name="combosel_resolution"/>
-   </item>
-   <item row="5" column="5">
-    <widget class="QLineEdit" name="valuetext_y_max"/>
-   </item>
-   <item row="2" column="3" colspan="2">
-    <widget class="QSlider" name="value_x_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>z axis</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="5">
-    <widget class="QLineEdit" name="valuetext_x_max"/>
-   </item>
-   <item row="12" column="2" colspan="4">
-    <layout class="QVBoxLayout" name="layout_slices"/>
-   </item>
-   <item row="1" column="3">
-    <widget class="QLineEdit" name="valuetext_x_min"/>
-   </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11"/>
  <resources/>
  <connections/>
 </ui>

--- a/glue_vispy_viewers/tests/images/py311-test-visual.json
+++ b/glue_vispy_viewers/tests/images/py311-test-visual.json
@@ -12,6 +12,7 @@
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_basic": "e5ee4a44748f02c68fb831f7be71c8f83e59d923ae8ecf4361945b418aacd4a3",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_colormap": "1f36100ca6981215aebc759004269fabf0ed238895aa96b26fde4cfa3df49027",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_native_aspect": "a473988dbc5e8f7fd6898459384de1381221c2fbcaa1a09090050cfb1915fe18",
+  "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_cutting_plane": "02470bd07afab598cd647c455b9e759693eab33c003409345f9dd4c33cd8e1c3",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_subset": "4913eae5ba0c725b0c0006e910a851877c751caf0e4a65359268b47a95bb1bfe",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_clip_off": "df4417eecd7596a7682cfb611a7c0ffab2ca7c7e8b19bc1c7785e9965c9114ab",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_scatter_overlay": "4821cc23b54fed2e2d484e32921e9ec6a196d9afda5b4e3f5998242f38626175"

--- a/glue_vispy_viewers/tests/images/py311-test-visual.json
+++ b/glue_vispy_viewers/tests/images/py311-test-visual.json
@@ -12,7 +12,7 @@
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_basic": "e5ee4a44748f02c68fb831f7be71c8f83e59d923ae8ecf4361945b418aacd4a3",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_colormap": "1f36100ca6981215aebc759004269fabf0ed238895aa96b26fde4cfa3df49027",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_native_aspect": "a473988dbc5e8f7fd6898459384de1381221c2fbcaa1a09090050cfb1915fe18",
-  "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_cutting_plane": "0a6085767ae4d1dba3d793fe73372ab88ea9f2e3b61b7d7daa79c2d68707a307",
+  "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_cutting_plane": "fb5e99659c706fceccf61f4f707ea1206f3a5ee6ddf62ec60256ecf36f46ede1",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_subset": "4913eae5ba0c725b0c0006e910a851877c751caf0e4a65359268b47a95bb1bfe",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_clip_off": "df4417eecd7596a7682cfb611a7c0ffab2ca7c7e8b19bc1c7785e9965c9114ab",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_scatter_overlay": "4821cc23b54fed2e2d484e32921e9ec6a196d9afda5b4e3f5998242f38626175"

--- a/glue_vispy_viewers/tests/images/py311-test-visual.json
+++ b/glue_vispy_viewers/tests/images/py311-test-visual.json
@@ -12,7 +12,7 @@
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_basic": "e5ee4a44748f02c68fb831f7be71c8f83e59d923ae8ecf4361945b418aacd4a3",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_colormap": "1f36100ca6981215aebc759004269fabf0ed238895aa96b26fde4cfa3df49027",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_native_aspect": "a473988dbc5e8f7fd6898459384de1381221c2fbcaa1a09090050cfb1915fe18",
-  "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_cutting_plane": "91e9869168169ac55ea33dc7fae0490c8c1c3bad8b3574af5e3971cce7d18391",
+  "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_cutting_plane": "0a6085767ae4d1dba3d793fe73372ab88ea9f2e3b61b7d7daa79c2d68707a307",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_subset": "4913eae5ba0c725b0c0006e910a851877c751caf0e4a65359268b47a95bb1bfe",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_clip_off": "df4417eecd7596a7682cfb611a7c0ffab2ca7c7e8b19bc1c7785e9965c9114ab",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_scatter_overlay": "4821cc23b54fed2e2d484e32921e9ec6a196d9afda5b4e3f5998242f38626175"

--- a/glue_vispy_viewers/tests/images/py311-test-visual.json
+++ b/glue_vispy_viewers/tests/images/py311-test-visual.json
@@ -12,7 +12,7 @@
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_basic": "e5ee4a44748f02c68fb831f7be71c8f83e59d923ae8ecf4361945b418aacd4a3",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_colormap": "1f36100ca6981215aebc759004269fabf0ed238895aa96b26fde4cfa3df49027",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_native_aspect": "a473988dbc5e8f7fd6898459384de1381221c2fbcaa1a09090050cfb1915fe18",
-  "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_cutting_plane": "02470bd07afab598cd647c455b9e759693eab33c003409345f9dd4c33cd8e1c3",
+  "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_cutting_plane": "3dac566bea4d4f8a0df2f09d6e7ce9a1661795feae6df580d57174ec1516372b",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_subset": "4913eae5ba0c725b0c0006e910a851877c751caf0e4a65359268b47a95bb1bfe",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_clip_off": "df4417eecd7596a7682cfb611a7c0ffab2ca7c7e8b19bc1c7785e9965c9114ab",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_scatter_overlay": "4821cc23b54fed2e2d484e32921e9ec6a196d9afda5b4e3f5998242f38626175"

--- a/glue_vispy_viewers/tests/images/py311-test-visual.json
+++ b/glue_vispy_viewers/tests/images/py311-test-visual.json
@@ -12,7 +12,7 @@
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_basic": "e5ee4a44748f02c68fb831f7be71c8f83e59d923ae8ecf4361945b418aacd4a3",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_colormap": "1f36100ca6981215aebc759004269fabf0ed238895aa96b26fde4cfa3df49027",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_native_aspect": "a473988dbc5e8f7fd6898459384de1381221c2fbcaa1a09090050cfb1915fe18",
-  "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_cutting_plane": "3dac566bea4d4f8a0df2f09d6e7ce9a1661795feae6df580d57174ec1516372b",
+  "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_cutting_plane": "91e9869168169ac55ea33dc7fae0490c8c1c3bad8b3574af5e3971cce7d18391",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_subset": "4913eae5ba0c725b0c0006e910a851877c751caf0e4a65359268b47a95bb1bfe",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_clip_off": "df4417eecd7596a7682cfb611a7c0ffab2ca7c7e8b19bc1c7785e9965c9114ab",
   "glue_vispy_viewers.volume.tests.test_visual.test_visual_volume3d_scatter_overlay": "4821cc23b54fed2e2d484e32921e9ec6a196d9afda5b4e3f5998242f38626175"

--- a/glue_vispy_viewers/volume/jupyter/viewer_state_widget.py
+++ b/glue_vispy_viewers/volume/jupyter/viewer_state_widget.py
@@ -28,3 +28,6 @@ class Volume3DViewerStateWidget(v.VuetifyTemplate):
             "cut_mode": "selection",
             "cut_axis": "selection",
         })
+
+    def vue_flip_cut(self, *args):
+        self.state.flip_cut()

--- a/glue_vispy_viewers/volume/jupyter/viewer_state_widget.py
+++ b/glue_vispy_viewers/volume/jupyter/viewer_state_widget.py
@@ -23,4 +23,8 @@ class Volume3DViewerStateWidget(v.VuetifyTemplate):
         self.slice_helper = MultiSliceWidgetHelper(viewer_state)
         self.widget_slices = self.slice_helper.layout
 
-        autoconnect_callbacks_to_vue(viewer_state, self, extras={"resolution": "selection"})
+        autoconnect_callbacks_to_vue(viewer_state, self, extras={
+            "resolution": "selection",
+            "cut_mode": "selection",
+            "cut_axis": "selection",
+        })

--- a/glue_vispy_viewers/volume/jupyter/viewer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/viewer_state_widget.vue
@@ -34,6 +34,37 @@
         <div>
             <jupyter-widget :widget="widget_slices" />
         </div>
+        <div>
+            <v-subheader class="pl-0 slider-label">cutting plane</v-subheader>
+            <v-switch v-model="cut_enabled" hide-details style="margin-top: 0" />
+        </div>
+        <template v-if="cut_enabled">
+            <div>
+                <v-select label="mode" :items="cut_mode_items" v-model="cut_mode_selected" hide-details />
+            </div>
+            <template v-if="(cut_mode_items[cut_mode_selected] || {}).text === 'Simple'">
+                <div>
+                    <v-subheader class="pl-0 slider-label">axis</v-subheader>
+                    <v-btn-toggle :value="cut_axis_selected" @change="cut_axis_selected = $event" mandatory dense>
+                        <v-btn v-for="(item, idx) in cut_axis_items" :key="item.text" :value="idx" small>{{ item.text }}</v-btn>
+                    </v-btn-toggle>
+                </div>
+            </template>
+            <template v-else>
+                <div>
+                    <v-subheader class="pl-0 slider-label">tilt</v-subheader>
+                    <v-slider v-model="cut_tilt" :min="0" :max="3.14159" :step="0.01" hide-details thumb-label="hidden" />
+                </div>
+                <div>
+                    <v-subheader class="pl-0 slider-label">rotation</v-subheader>
+                    <v-slider v-model="cut_rotation" :min="0" :max="6.28318" :step="0.01" hide-details thumb-label="hidden" />
+                </div>
+            </template>
+            <div>
+                <v-subheader class="pl-0 slider-label">depth</v-subheader>
+                <v-slider v-model="cut_depth" :min="0" :max="1" :step="0.001" hide-details thumb-label="hidden" />
+            </div>
+        </template>
     </div>
 </template>
 

--- a/glue_vispy_viewers/volume/jupyter/viewer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/viewer_state_widget.vue
@@ -64,6 +64,9 @@
                 <v-subheader class="pl-0 slider-label">depth</v-subheader>
                 <v-slider v-model="cut_depth" :min="0" :max="1" :step="0.001" hide-details thumb-label="hidden" />
             </div>
+            <div>
+                <v-btn small block class="mt-2" @click="flip_cut">Flip shown/clipped side</v-btn>
+            </div>
         </template>
     </div>
 </template>

--- a/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
+++ b/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
@@ -82,6 +82,12 @@ class CuttingPlaneWidget(QtWidgets.QWidget):
         depth_layout.addWidget(self.value_cut_depth)
         layout.addWidget(self._depth_box)
 
+        # Flip button: swaps the shown and clipped sides of the plane. Named
+        # ``button_flip_cut`` so echo's autoconnect wires its click straight to
+        # ``state.flip_cut`` (Simple-mode cuts switch to Advanced when flipped).
+        self.button_flip_cut = QtWidgets.QPushButton('Flip shown/clipped side')
+        layout.addWidget(self.button_flip_cut)
+
         layout.addStretch(1)
 
     def _wire_radio_buttons(self):
@@ -114,7 +120,7 @@ class CuttingPlaneWidget(QtWidgets.QWidget):
     def _on_enabled_change(self, *args):
         on = bool(self.state.cut_enabled)
         for w in (self._mode_row_widget, self._simple_box,
-                  self._advanced_box, self._depth_box):
+                  self._advanced_box, self._depth_box, self.button_flip_cut):
             w.setEnabled(on)
 
     def _on_mode_change(self, *args):

--- a/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
+++ b/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
@@ -1,7 +1,10 @@
+import os
+
 import numpy as np
 
-from qtpy import QtCore, QtWidgets
+from qtpy import QtWidgets
 
+from glue_qt.utils import load_ui
 from echo.qt import autoconnect_callbacks_to_qt
 
 
@@ -13,14 +16,17 @@ class CuttingPlaneWidget(QtWidgets.QWidget):
 
     A toggle enables the cut; a Simple/Advanced selector switches between
     axis-aligned cuts (X/Y/Z radio buttons) and a free-orientation cut
-    driven by tilt/rotation sliders. A depth slider is always shown
-    while the cut is enabled.
+    driven by tilt/rotation sliders. A depth slider and a flip button are
+    always shown while the cut is enabled.
     """
 
     def __init__(self, viewer_state, parent=None):
         super().__init__(parent=parent)
         self.state = viewer_state
-        self._build_ui()
+
+        self.ui = load_ui('cutting_plane_widget.ui', self,
+                          directory=os.path.dirname(__file__))
+
         self._wire_radio_buttons()
         connect_kwargs = {
             'value_cut_tilt': dict(value_range=(0.0, np.pi)),
@@ -28,77 +34,21 @@ class CuttingPlaneWidget(QtWidgets.QWidget):
             'value_cut_depth': dict(value_range=(0.0, 1.0)),
         }
         self._connections = autoconnect_callbacks_to_qt(
-            self.state, self, connect_kwargs)
+            self.state, self.ui, connect_kwargs)
         self.state.add_callback('cut_enabled', self._on_enabled_change)
         self.state.add_callback('cut_mode', self._on_mode_change)
         self._on_enabled_change()
         self._on_mode_change()
 
-    def _build_ui(self):
-        layout = QtWidgets.QVBoxLayout(self)
-        layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(10)
-
-        self.bool_cut_enabled = QtWidgets.QCheckBox('Enable cutting plane')
-        layout.addWidget(self.bool_cut_enabled)
-
-        mode_row = QtWidgets.QHBoxLayout()
-        mode_row.addWidget(QtWidgets.QLabel('Mode:'))
-        self.combosel_cut_mode = QtWidgets.QComboBox()
-        mode_row.addWidget(self.combosel_cut_mode, 1)
-        self._mode_row_widget = QtWidgets.QWidget()
-        self._mode_row_widget.setLayout(mode_row)
-        layout.addWidget(self._mode_row_widget)
-
-        # Simple-mode axis radio buttons
-        self._simple_box = QtWidgets.QGroupBox('Axis')
-        simple_layout = QtWidgets.QHBoxLayout(self._simple_box)
-        self.radio_axis_x = QtWidgets.QRadioButton('X')
-        self.radio_axis_y = QtWidgets.QRadioButton('Y')
-        self.radio_axis_z = QtWidgets.QRadioButton('Z')
-        for w in (self.radio_axis_x, self.radio_axis_y, self.radio_axis_z):
-            simple_layout.addWidget(w)
-        layout.addWidget(self._simple_box)
-
-        # Advanced-mode angle sliders -- subheader-above-slider layout so
-        # each slider gets the full widget width.
-        self._advanced_box = QtWidgets.QGroupBox('Orientation')
-        adv_layout = QtWidgets.QVBoxLayout(self._advanced_box)
-        adv_layout.addWidget(QtWidgets.QLabel('Tilt'))
-        self.value_cut_tilt = QtWidgets.QSlider(QtCore.Qt.Horizontal)
-        self.value_cut_tilt.setRange(0, 180)
-        adv_layout.addWidget(self.value_cut_tilt)
-        adv_layout.addWidget(QtWidgets.QLabel('Rotation'))
-        self.value_cut_rotation = QtWidgets.QSlider(QtCore.Qt.Horizontal)
-        self.value_cut_rotation.setRange(0, 360)
-        adv_layout.addWidget(self.value_cut_rotation)
-        layout.addWidget(self._advanced_box)
-
-        # Depth slider
-        self._depth_box = QtWidgets.QGroupBox('Depth')
-        depth_layout = QtWidgets.QVBoxLayout(self._depth_box)
-        self.value_cut_depth = QtWidgets.QSlider(QtCore.Qt.Horizontal)
-        self.value_cut_depth.setRange(0, 1000)
-        depth_layout.addWidget(self.value_cut_depth)
-        layout.addWidget(self._depth_box)
-
-        # Flip button: toggles which side of the plane is shown. Named
-        # ``button_flip_cut`` so echo's autoconnect wires its click straight to
-        # ``state.flip_cut``, which just toggles the ``cut_flip`` boolean.
-        self.button_flip_cut = QtWidgets.QPushButton('Flip shown/clipped side')
-        layout.addWidget(self.button_flip_cut)
-
-        layout.addStretch(1)
-
     def _wire_radio_buttons(self):
         # Axis radio buttons aren't covered by echo's autoconnect, so wire
         # them by hand: button toggle -> state.cut_axis, and the reverse.
         self._axis_group = QtWidgets.QButtonGroup(self)
-        for i, w in enumerate((self.radio_axis_x, self.radio_axis_y, self.radio_axis_z)):
-            self._axis_group.addButton(w, i)
-        self._axis_buttons = {'X': self.radio_axis_x,
-                              'Y': self.radio_axis_y,
-                              'Z': self.radio_axis_z}
+        self._axis_buttons = {'X': self.ui.radio_axis_x,
+                              'Y': self.ui.radio_axis_y,
+                              'Z': self.ui.radio_axis_z}
+        for i, btn in enumerate(self._axis_buttons.values()):
+            self._axis_group.addButton(btn, i)
 
         def on_toggled(checked):
             for ax, btn in self._axis_buttons.items():
@@ -119,11 +69,12 @@ class CuttingPlaneWidget(QtWidgets.QWidget):
 
     def _on_enabled_change(self, *args):
         on = bool(self.state.cut_enabled)
-        for w in (self._mode_row_widget, self._simple_box,
-                  self._advanced_box, self._depth_box, self.button_flip_cut):
+        for w in (self.ui.mode_row, self.ui.simple_box,
+                  self.ui.advanced_box, self.ui.depth_box,
+                  self.ui.button_flip_cut):
             w.setEnabled(on)
 
     def _on_mode_change(self, *args):
         simple = (self.state.cut_mode == 'Simple')
-        self._simple_box.setVisible(simple)
-        self._advanced_box.setVisible(not simple)
+        self.ui.simple_box.setVisible(simple)
+        self.ui.advanced_box.setVisible(not simple)

--- a/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
+++ b/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
@@ -1,0 +1,120 @@
+import numpy as np
+
+from qtpy import QtCore, QtWidgets
+
+from echo.qt import autoconnect_callbacks_to_qt
+
+
+__all__ = ['CuttingPlaneWidget']
+
+
+class CuttingPlaneWidget(QtWidgets.QWidget):
+    """Qt controls for the volume viewer's cutting plane.
+
+    A toggle enables the cut; a Simple/Advanced selector switches between
+    axis-aligned cuts (X/Y/Z radio buttons) and a free-orientation cut
+    driven by tilt/rotation sliders. A depth slider is always shown
+    while the cut is enabled.
+    """
+
+    def __init__(self, viewer_state, parent=None):
+        super().__init__(parent=parent)
+        self.state = viewer_state
+        self._build_ui()
+        self._wire_radio_buttons()
+        connect_kwargs = {
+            'value_cut_tilt': dict(value_range=(0.0, np.pi)),
+            'value_cut_rotation': dict(value_range=(0.0, 2.0 * np.pi)),
+            'value_cut_depth': dict(value_range=(0.0, 1.0)),
+        }
+        self._connections = autoconnect_callbacks_to_qt(
+            self.state, self, connect_kwargs)
+        self.state.add_callback('cut_enabled', self._on_enabled_change)
+        self.state.add_callback('cut_mode', self._on_mode_change)
+        self._on_enabled_change()
+        self._on_mode_change()
+
+    def _build_ui(self):
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(10)
+
+        self.bool_cut_enabled = QtWidgets.QCheckBox('Enable cutting plane')
+        layout.addWidget(self.bool_cut_enabled)
+
+        mode_row = QtWidgets.QHBoxLayout()
+        mode_row.addWidget(QtWidgets.QLabel('Mode:'))
+        self.combosel_cut_mode = QtWidgets.QComboBox()
+        mode_row.addWidget(self.combosel_cut_mode, 1)
+        self._mode_row_widget = QtWidgets.QWidget()
+        self._mode_row_widget.setLayout(mode_row)
+        layout.addWidget(self._mode_row_widget)
+
+        # Simple-mode axis radio buttons
+        self._simple_box = QtWidgets.QGroupBox('Axis')
+        simple_layout = QtWidgets.QHBoxLayout(self._simple_box)
+        self.radio_axis_x = QtWidgets.QRadioButton('X')
+        self.radio_axis_y = QtWidgets.QRadioButton('Y')
+        self.radio_axis_z = QtWidgets.QRadioButton('Z')
+        for w in (self.radio_axis_x, self.radio_axis_y, self.radio_axis_z):
+            simple_layout.addWidget(w)
+        layout.addWidget(self._simple_box)
+
+        # Advanced-mode angle sliders
+        self._advanced_box = QtWidgets.QGroupBox('Orientation')
+        adv_layout = QtWidgets.QFormLayout(self._advanced_box)
+        self.value_cut_tilt = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.value_cut_tilt.setRange(0, 180)
+        self.value_cut_rotation = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.value_cut_rotation.setRange(0, 360)
+        adv_layout.addRow('Tilt', self.value_cut_tilt)
+        adv_layout.addRow('Rotation', self.value_cut_rotation)
+        layout.addWidget(self._advanced_box)
+
+        # Depth slider
+        self._depth_box = QtWidgets.QGroupBox('Depth')
+        depth_layout = QtWidgets.QVBoxLayout(self._depth_box)
+        self.value_cut_depth = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.value_cut_depth.setRange(0, 1000)
+        depth_layout.addWidget(self.value_cut_depth)
+        layout.addWidget(self._depth_box)
+
+        layout.addStretch(1)
+
+    def _wire_radio_buttons(self):
+        # Axis radio buttons aren't covered by echo's autoconnect, so wire
+        # them by hand: button toggle -> state.cut_axis, and the reverse.
+        self._axis_group = QtWidgets.QButtonGroup(self)
+        for i, w in enumerate((self.radio_axis_x, self.radio_axis_y, self.radio_axis_z)):
+            self._axis_group.addButton(w, i)
+        self._axis_buttons = {'X': self.radio_axis_x,
+                              'Y': self.radio_axis_y,
+                              'Z': self.radio_axis_z}
+
+        def on_toggled(checked, axis=None):
+            for ax, btn in self._axis_buttons.items():
+                if btn.isChecked():
+                    if self.state.cut_axis != ax:
+                        self.state.cut_axis = ax
+                    return
+
+        for btn in self._axis_buttons.values():
+            btn.toggled.connect(on_toggled)
+        self.state.add_callback('cut_axis', self._sync_axis_buttons)
+        self._sync_axis_buttons()
+
+    def _sync_axis_buttons(self, *args):
+        btn = self._axis_buttons.get(self.state.cut_axis)
+        if btn is not None and not btn.isChecked():
+            btn.setChecked(True)
+
+    def _on_enabled_change(self, *args):
+        on = bool(self.state.cut_enabled)
+        for w in (self._mode_row_widget, self._simple_box,
+                  self._advanced_box, self._depth_box):
+            w.setEnabled(on)
+
+    def _on_mode_change(self, *args):
+        simple = (self.state.cut_mode == 'Simple')
+        self._simple_box.setVisible(simple)
+        self._advanced_box.setVisible(not simple)

--- a/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
+++ b/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
@@ -100,7 +100,7 @@ class CuttingPlaneWidget(QtWidgets.QWidget):
                               'Y': self.radio_axis_y,
                               'Z': self.radio_axis_z}
 
-        def on_toggled(checked, axis=None):
+        def on_toggled(checked):
             for ax, btn in self._axis_buttons.items():
                 if btn.isChecked():
                     if self.state.cut_axis != ax:

--- a/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
+++ b/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
@@ -60,15 +60,18 @@ class CuttingPlaneWidget(QtWidgets.QWidget):
             simple_layout.addWidget(w)
         layout.addWidget(self._simple_box)
 
-        # Advanced-mode angle sliders
+        # Advanced-mode angle sliders -- subheader-above-slider layout so
+        # each slider gets the full widget width.
         self._advanced_box = QtWidgets.QGroupBox('Orientation')
-        adv_layout = QtWidgets.QFormLayout(self._advanced_box)
+        adv_layout = QtWidgets.QVBoxLayout(self._advanced_box)
+        adv_layout.addWidget(QtWidgets.QLabel('Tilt'))
         self.value_cut_tilt = QtWidgets.QSlider(QtCore.Qt.Horizontal)
         self.value_cut_tilt.setRange(0, 180)
+        adv_layout.addWidget(self.value_cut_tilt)
+        adv_layout.addWidget(QtWidgets.QLabel('Rotation'))
         self.value_cut_rotation = QtWidgets.QSlider(QtCore.Qt.Horizontal)
         self.value_cut_rotation.setRange(0, 360)
-        adv_layout.addRow('Tilt', self.value_cut_tilt)
-        adv_layout.addRow('Rotation', self.value_cut_rotation)
+        adv_layout.addWidget(self.value_cut_rotation)
         layout.addWidget(self._advanced_box)
 
         # Depth slider

--- a/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
+++ b/glue_vispy_viewers/volume/qt/cutting_plane_widget.py
@@ -82,9 +82,9 @@ class CuttingPlaneWidget(QtWidgets.QWidget):
         depth_layout.addWidget(self.value_cut_depth)
         layout.addWidget(self._depth_box)
 
-        # Flip button: swaps the shown and clipped sides of the plane. Named
+        # Flip button: toggles which side of the plane is shown. Named
         # ``button_flip_cut`` so echo's autoconnect wires its click straight to
-        # ``state.flip_cut`` (Simple-mode cuts switch to Advanced when flipped).
+        # ``state.flip_cut``, which just toggles the ``cut_flip`` boolean.
         self.button_flip_cut = QtWidgets.QPushButton('Flip shown/clipped side')
         layout.addWidget(self.button_flip_cut)
 

--- a/glue_vispy_viewers/volume/qt/cutting_plane_widget.ui
+++ b/glue_vispy_viewers/volume/qt/cutting_plane_widget.ui
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>276</width>
+    <height>360</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Cutting plane</string>
+  </property>
+  <layout class="QVBoxLayout" name="layout">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="leftMargin">
+    <number>8</number>
+   </property>
+   <property name="topMargin">
+    <number>8</number>
+   </property>
+   <property name="rightMargin">
+    <number>8</number>
+   </property>
+   <property name="bottomMargin">
+    <number>8</number>
+   </property>
+   <item>
+    <widget class="QCheckBox" name="bool_cut_enabled">
+     <property name="text">
+      <string>Enable cutting plane</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="mode_row" native="true">
+     <layout class="QHBoxLayout" name="mode_layout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label_mode">
+        <property name="text">
+         <string>Mode:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="combosel_cut_mode"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="simple_box">
+     <property name="title">
+      <string>Axis</string>
+     </property>
+     <layout class="QHBoxLayout" name="simple_layout">
+      <item>
+       <widget class="QRadioButton" name="radio_axis_x">
+        <property name="text">
+         <string>X</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radio_axis_y">
+        <property name="text">
+         <string>Y</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radio_axis_z">
+        <property name="text">
+         <string>Z</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="advanced_box">
+     <property name="title">
+      <string>Orientation</string>
+     </property>
+     <layout class="QVBoxLayout" name="advanced_layout">
+      <item>
+       <widget class="QLabel" name="label_tilt">
+        <property name="text">
+         <string>Tilt</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSlider" name="value_cut_tilt">
+        <property name="maximum">
+         <number>180</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_rotation">
+        <property name="text">
+         <string>Rotation</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSlider" name="value_cut_rotation">
+        <property name="maximum">
+         <number>360</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="depth_box">
+     <property name="title">
+      <string>Depth</string>
+     </property>
+     <layout class="QVBoxLayout" name="depth_layout">
+      <item>
+       <widget class="QSlider" name="value_cut_depth">
+        <property name="maximum">
+         <number>1000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="button_flip_cut">
+     <property name="text">
+      <string>Flip shown/clipped side</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/glue_vispy_viewers/volume/qt/viewer_options.py
+++ b/glue_vispy_viewers/volume/qt/viewer_options.py
@@ -1,4 +1,4 @@
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from ...common.qt.viewer_options import VispyOptionsWidget
 from .cutting_plane_widget import CuttingPlaneWidget
@@ -10,10 +10,11 @@ __all__ = ['VolumeOptionsWidget']
 class VolumeOptionsWidget(QtWidgets.QWidget):
     """Tabbed viewer-options widget for the volume viewer.
 
-    The first tab embeds the shared ``VispyOptionsWidget`` (axes, limits,
-    stretch, slices, resolution). The second tab holds the cutting plane
-    controls -- a feature only the volume viewer has, which is why this
-    wrapper lives here rather than next to the shared widget.
+    "General" embeds the shared ``VispyOptionsWidget`` (axes, stretch,
+    slices, resolution, reference data). "Limits" reparents the min/max
+    inputs and flip buttons out of the shared widget into a tab modelled
+    on glue-qt's 2D image viewer. "Cutting plane" holds the cutting plane
+    controls.
     """
 
     def __init__(self, viewer_state=None, session=None, parent=None):
@@ -28,6 +29,9 @@ class VolumeOptionsWidget(QtWidgets.QWidget):
             viewer_state=viewer_state, session=session, parent=self)
         self._tabs.addTab(self.general, 'General')
 
+        self.limits = self._build_limits_tab()
+        self._tabs.addTab(self.limits, 'Limits')
+
         self.cutting_plane = CuttingPlaneWidget(viewer_state=viewer_state, parent=self)
         self._tabs.addTab(self.cutting_plane, 'Cutting plane')
 
@@ -37,3 +41,48 @@ class VolumeOptionsWidget(QtWidgets.QWidget):
         self.ui = self.general.ui
         if hasattr(self.general, 'slice_helper'):
             self.slice_helper = self.general.slice_helper
+
+    def _build_limits_tab(self):
+        ui = self.general.ui
+        tab = QtWidgets.QWidget()
+        grid = QtWidgets.QGridLayout(tab)
+        grid.setContentsMargins(10, 10, 10, 10)
+        grid.setHorizontalSpacing(8)
+        grid.setVerticalSpacing(6)
+
+        header_min = QtWidgets.QLabel('min')
+        header_max = QtWidgets.QLabel('max')
+        for header in (header_min, header_max):
+            f = header.font()
+            f.setBold(True)
+            header.setFont(f)
+            header.setAlignment(QtCore.Qt.AlignCenter)
+        grid.addWidget(header_min, 0, 1)
+        grid.addWidget(header_max, 0, 3)
+
+        axes = (('x axis', ui.valuetext_x_min, ui.valuetext_x_max, ui.button_flip_x),
+                ('y axis', ui.valuetext_y_min, ui.valuetext_y_max, ui.button_flip_y),
+                ('z axis', ui.valuetext_z_min, ui.valuetext_z_max, ui.button_flip_z))
+        for row, (axis_label, lo, hi, flip) in enumerate(axes, start=1):
+            label = QtWidgets.QLabel(axis_label)
+            f = label.font()
+            f.setBold(True)
+            label.setFont(f)
+            grid.addWidget(label, row, 0)
+            grid.addWidget(lo, row, 1)
+            grid.addWidget(flip, row, 2)
+            grid.addWidget(hi, row, 3)
+
+        grid.setRowStretch(len(axes) + 1, 1)
+        grid.setColumnStretch(1, 1)
+        grid.setColumnStretch(3, 1)
+
+        # Hide the now-orphaned "min/max:" labels left behind in the
+        # General tab. They share the same object name (``label_2``)
+        # so ``self.ui.label_2`` only exposes the last one -- walk the
+        # children to find them all.
+        for child in self.general.findChildren(QtWidgets.QLabel):
+            if child.text() == 'min/max:':
+                child.hide()
+
+        return tab

--- a/glue_vispy_viewers/volume/qt/viewer_options.py
+++ b/glue_vispy_viewers/volume/qt/viewer_options.py
@@ -1,0 +1,39 @@
+from qtpy import QtWidgets
+
+from ...common.qt.viewer_options import VispyOptionsWidget
+from .cutting_plane_widget import CuttingPlaneWidget
+
+
+__all__ = ['VolumeOptionsWidget']
+
+
+class VolumeOptionsWidget(QtWidgets.QWidget):
+    """Tabbed viewer-options widget for the volume viewer.
+
+    The first tab embeds the shared ``VispyOptionsWidget`` (axes, limits,
+    stretch, slices, resolution). The second tab holds the cutting plane
+    controls -- a feature only the volume viewer has, which is why this
+    wrapper lives here rather than next to the shared widget.
+    """
+
+    def __init__(self, viewer_state=None, session=None, parent=None):
+        super().__init__(parent=parent)
+
+        self._tabs = QtWidgets.QTabWidget(self)
+        outer = QtWidgets.QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.addWidget(self._tabs)
+
+        self.general = VispyOptionsWidget(
+            viewer_state=viewer_state, session=session, parent=self)
+        self._tabs.addTab(self.general, 'General')
+
+        self.cutting_plane = CuttingPlaneWidget(viewer_state=viewer_state, parent=self)
+        self._tabs.addTab(self.cutting_plane, 'Cutting plane')
+
+        # Expose the helpers the rest of the viewer pokes at on the
+        # shared widget (notably the slice helper) at the top level for
+        # API compatibility with code that expects the flat widget.
+        self.ui = self.general.ui
+        if hasattr(self.general, 'slice_helper'):
+            self.slice_helper = self.general.slice_helper

--- a/glue_vispy_viewers/volume/qt/viewer_options.py
+++ b/glue_vispy_viewers/volume/qt/viewer_options.py
@@ -1,5 +1,3 @@
-from qtpy import QtCore, QtWidgets
-
 from ...common.qt.viewer_options import VispyOptionsWidget
 from .cutting_plane_widget import CuttingPlaneWidget
 
@@ -7,82 +5,17 @@ from .cutting_plane_widget import CuttingPlaneWidget
 __all__ = ['VolumeOptionsWidget']
 
 
-class VolumeOptionsWidget(QtWidgets.QWidget):
-    """Tabbed viewer-options widget for the volume viewer.
+class VolumeOptionsWidget(VispyOptionsWidget):
+    """Volume viewer options: the shared General/Limits tabs plus a cutting
+    plane tab.
 
-    "General" embeds the shared ``VispyOptionsWidget`` (axes, stretch,
-    slices, resolution, reference data). "Limits" reparents the min/max
-    inputs and flip buttons out of the shared widget into a tab modelled
-    on glue-qt's 2D image viewer. "Cutting plane" holds the cutting plane
-    controls.
+    Extends the shared :class:`VispyOptionsWidget` (which provides the
+    "General" and "Limits" tabs) by appending a "Cutting plane" tab with the
+    volume-specific cutting plane controls.
     """
 
     def __init__(self, viewer_state=None, session=None, parent=None):
-        super().__init__(parent=parent)
-
-        self._tabs = QtWidgets.QTabWidget(self)
-        outer = QtWidgets.QVBoxLayout(self)
-        outer.setContentsMargins(0, 0, 0, 0)
-        outer.addWidget(self._tabs)
-
-        self.general = VispyOptionsWidget(
-            viewer_state=viewer_state, session=session, parent=self)
-        self._tabs.addTab(self.general, 'General')
-
-        self.limits = self._build_limits_tab()
-        self._tabs.addTab(self.limits, 'Limits')
+        super().__init__(viewer_state=viewer_state, session=session, parent=parent)
 
         self.cutting_plane = CuttingPlaneWidget(viewer_state=viewer_state, parent=self)
         self._tabs.addTab(self.cutting_plane, 'Cutting plane')
-
-        # Expose the helpers the rest of the viewer pokes at on the
-        # shared widget (notably the slice helper) at the top level for
-        # API compatibility with code that expects the flat widget.
-        self.ui = self.general.ui
-        if hasattr(self.general, 'slice_helper'):
-            self.slice_helper = self.general.slice_helper
-
-    def _build_limits_tab(self):
-        ui = self.general.ui
-        tab = QtWidgets.QWidget()
-        grid = QtWidgets.QGridLayout(tab)
-        grid.setContentsMargins(10, 10, 10, 10)
-        grid.setHorizontalSpacing(8)
-        grid.setVerticalSpacing(6)
-
-        header_min = QtWidgets.QLabel('min')
-        header_max = QtWidgets.QLabel('max')
-        for header in (header_min, header_max):
-            f = header.font()
-            f.setBold(True)
-            header.setFont(f)
-            header.setAlignment(QtCore.Qt.AlignCenter)
-        grid.addWidget(header_min, 0, 1)
-        grid.addWidget(header_max, 0, 3)
-
-        axes = (('x axis', ui.valuetext_x_min, ui.valuetext_x_max, ui.button_flip_x),
-                ('y axis', ui.valuetext_y_min, ui.valuetext_y_max, ui.button_flip_y),
-                ('z axis', ui.valuetext_z_min, ui.valuetext_z_max, ui.button_flip_z))
-        for row, (axis_label, lo, hi, flip) in enumerate(axes, start=1):
-            label = QtWidgets.QLabel(axis_label)
-            f = label.font()
-            f.setBold(True)
-            label.setFont(f)
-            grid.addWidget(label, row, 0)
-            grid.addWidget(lo, row, 1)
-            grid.addWidget(flip, row, 2)
-            grid.addWidget(hi, row, 3)
-
-        grid.setRowStretch(len(axes) + 1, 1)
-        grid.setColumnStretch(1, 1)
-        grid.setColumnStretch(3, 1)
-
-        # Hide the now-orphaned "min/max:" labels left behind in the
-        # General tab. They share the same object name (``label_2``)
-        # so ``self.ui.label_2`` only exposes the last one -- walk the
-        # children to find them all.
-        for child in self.general.findChildren(QtWidgets.QLabel):
-            if child.text() == 'min/max:':
-                child.hide()
-
-        return tab

--- a/glue_vispy_viewers/volume/qt/volume_viewer.py
+++ b/glue_vispy_viewers/volume/qt/volume_viewer.py
@@ -6,6 +6,7 @@ from qtpy.QtCore import QTimer
 
 from ...common.qt.data_viewer import BaseVispyViewer
 from .layer_style_widget import VolumeLayerStyleWidget
+from .viewer_options import VolumeOptionsWidget
 
 from glue.viewers.volume3d.layer_state import VolumeLayerState3D
 
@@ -17,6 +18,8 @@ from ...scatter.qt.layer_style_widget import ScatterLayerStyleWidget
 
 
 class VispyVolumeViewer(VispyVolumeViewerMixin, BaseVispyViewer):
+
+    _options_cls = VolumeOptionsWidget
 
     _layer_style_widget_cls = {VolumeLayerArtist: VolumeLayerStyleWidget,
                                ScatterLayerArtist: ScatterLayerStyleWidget}

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -80,6 +80,10 @@ varying vec3 v_position;
 varying vec4 v_nearpos;
 varying vec4 v_farpos;
 
+// A cutting plane defined as ax + by + cz + d = 0 where the vector below is (a, b, c)
+uniform vec3 u_cutting_plane_abc;
+uniform float u_cutting_plane_d;
+
 // uniforms for lighting. Hard coded until we figure out how to do lights
 const vec4 u_ambient = vec4(0.2, 0.4, 0.2, 1.0);
 const vec4 u_diffuse = vec4(0.8, 0.2, 0.2, 1.0);
@@ -120,6 +124,10 @@ void main() {{
                             (u_shape.y - 0.5 - v_position.y) / view_ray.y));
     distance = max(distance, min((-0.5 - v_position.z) / view_ray.z,
                             (u_shape.z - 0.5 - v_position.z) / view_ray.z));
+
+    // Compute distance to cutting plane
+    float cutting_distance = -(dot(v_position, u_cutting_plane_abc) + u_cutting_plane_d) / dot(view_ray, u_cutting_plane_abc);
+    distance = max(distance, cutting_distance);
 
     // Now we have the starting position on the front surface
     vec3 front = v_position + view_ray * distance;

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -80,7 +80,11 @@ varying vec3 v_position;
 varying vec4 v_nearpos;
 varying vec4 v_farpos;
 
-// A cutting plane defined as ax + by + cz + d = 0 where the vector below is (a, b, c)
+// A cutting plane defined as ax + by + cz + d = 0 where the vector below is (a, b, c).
+// u_cutting_plane_enabled is a 0/1 flag so we can skip the computation (and avoid
+// the division-by-zero that happens when a ray is parallel to the plane) when no
+// cut is set.
+uniform int u_cutting_plane_enabled;
 uniform vec3 u_cutting_plane_abc;
 uniform float u_cutting_plane_d;
 
@@ -125,9 +129,11 @@ void main() {{
     distance = max(distance, min((-0.5 - v_position.z) / view_ray.z,
                             (u_shape.z - 0.5 - v_position.z) / view_ray.z));
 
-    // Compute distance to cutting plane
-    float cutting_distance = -(dot(v_position, u_cutting_plane_abc) + u_cutting_plane_d) / dot(view_ray, u_cutting_plane_abc);
-    distance = max(distance, cutting_distance);
+    // If a cutting plane is set, push the front surface forward to it
+    if (u_cutting_plane_enabled == 1) {{
+        float cutting_distance = -(dot(v_position, u_cutting_plane_abc) + u_cutting_plane_d) / dot(view_ray, u_cutting_plane_abc);
+        distance = max(distance, cutting_distance);
+    }}
 
     // Now we have the starting position on the front surface
     vec3 front = v_position + view_ray * distance;

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -129,21 +129,41 @@ void main() {{
     distance = max(distance, min((-0.5 - v_position.z) / view_ray.z,
                             (u_shape.z - 0.5 - v_position.z) / view_ray.z));
 
-    // If a cutting plane is set, push the front surface forward to it
+    // Restrict the sampling segment to the "kept" side of the cutting plane.
+    // The kept side is defined in volume coordinates as
+    //     dot(p, u_cutting_plane_abc) + u_cutting_plane_d < 0
+    // i.e. the half-space opposite the plane normal. Defining the kept side
+    // this way (rather than implicitly via the ray direction) makes the
+    // result invariant under camera rotation: rotating the view shows the
+    // same kept material from a different angle, rather than flipping which
+    // material is visible.
+    float exit_distance = 0.0;
     if (u_cutting_plane_enabled == 1) {{
-        float cutting_distance = -(dot(v_position, u_cutting_plane_abc) + u_cutting_plane_d) / dot(view_ray, u_cutting_plane_abc);
-        distance = max(distance, cutting_distance);
+        float v0 = dot(v_position, u_cutting_plane_abc) + u_cutting_plane_d;
+        float vdir = dot(view_ray, u_cutting_plane_abc);
+        if (abs(vdir) < 1e-6) {{
+            if (v0 > 0.0) discard;
+        }} else {{
+            float t_plane = -v0 / vdir;
+            if (vdir > 0.0) {{
+                exit_distance = min(exit_distance, t_plane);
+            }} else {{
+                distance = max(distance, t_plane);
+            }}
+        }}
     }}
+    if (exit_distance <= distance) discard;
 
     // Now we have the starting position on the front surface
     vec3 front = v_position + view_ray * distance;
+    vec3 back = v_position + view_ray * exit_distance;
 
     // Decide how many steps to take
-    int nsteps = int(-distance / u_downsample + 0.5);
+    int nsteps = int((exit_distance - distance) / u_downsample + 0.5);
     if(nsteps < 1) discard;
 
     // Get starting location and step vector in texture coordinates
-    vec3 step = ((v_position - front) / u_shape) / nsteps;
+    vec3 step = ((back - front) / u_shape) / nsteps;
     vec3 start_loc = front / u_shape;
 
     float val;

--- a/glue_vispy_viewers/volume/tests/scenes.py
+++ b/glue_vispy_viewers/volume/tests/scenes.py
@@ -113,14 +113,16 @@ def volume_clip_off(viewer):
 
 
 def volume_cutting_plane(viewer):
-    """L1448 with a plasma colormap and a diagonal cutting plane.
+    """L1448 with a plasma colormap and a tilted top cutting plane.
 
     The plane is set to ``ax + by + cz + d = 0`` with ``(a, b, c, d) =
-    (1, 1, 0, -80)``, which slices the cube diagonally across the
-    velocity/x axis. The render should show roughly half the cube
-    revealed; setting ``cutting_plane=None`` and re-rendering would
-    bring the rest back. Used to verify that the cutting-plane uniforms
-    reach the GPU and that the disabled/enabled toggle path is wired up.
+    (0, 0.5, 1, -180)``: a roughly horizontal cut tilted along the
+    depth axis. The camera is rotated 180 degrees around the z-axis
+    from its default azimuth so the cut surface faces the viewer.
+    Roughly half the volume is removed, leaving the bright L1448 cloud
+    sliced open from above. Used to verify that the cutting plane
+    uniforms reach the GPU and that the enabled/disabled toggle path
+    is wired up.
     """
     import matplotlib.pyplot as plt
     layer = viewer.state.layers[0]
@@ -129,7 +131,8 @@ def volume_cutting_plane(viewer):
     layer.cmap = plt.cm.plasma
     layer.v_min = -0.7
     layer.v_max = 2.74
-    viewer.state.cutting_plane = (1.0, 1.0, 0.0, -80.0)
+    viewer.state.cutting_plane = (0.0, 0.5, 1.0, -180.0)
+    viewer._vispy_widget.view.camera.azimuth += 180
 
 
 def volume_with_scatter_overlay(app, viewer, vol_data, scatter_data):

--- a/glue_vispy_viewers/volume/tests/scenes.py
+++ b/glue_vispy_viewers/volume/tests/scenes.py
@@ -115,14 +115,13 @@ def volume_clip_off(viewer):
 def volume_cutting_plane(viewer):
     """L1448 with a plasma colormap and a tilted top cutting plane.
 
-    The plane is set to ``ax + by + cz + d = 0`` with ``(a, b, c, d) =
-    (0, 0.5, 1, -180)``: a roughly horizontal cut tilted along the
-    depth axis. The camera is rotated 180 degrees around the z-axis
-    from its default azimuth so the cut surface faces the viewer.
-    Roughly half the volume is removed, leaving the bright L1448 cloud
-    sliced open from above. Used to verify that the cutting plane
-    uniforms reach the GPU and that the enabled/disabled toggle path
-    is wired up.
+    Exercises the advanced-mode cutting plane controls. The chosen
+    ``cut_tilt``/``cut_rotation``/``cut_depth`` reproduce the shader
+    plane ``0.5 y + z = 180`` (in 0..256 v_position coordinates), a
+    roughly horizontal cut tilted along the depth axis. The camera is
+    rotated 180 degrees around the z-axis from its default azimuth so
+    the cut surface faces the viewer. Roughly half the volume is
+    removed, leaving the bright L1448 cloud sliced open from above.
     """
     import matplotlib.pyplot as plt
     layer = viewer.state.layers[0]
@@ -131,7 +130,14 @@ def volume_cutting_plane(viewer):
     layer.cmap = plt.cm.plasma
     layer.v_min = -0.7
     layer.v_max = 2.74
-    viewer.state.cutting_plane = (0.0, 0.5, 1.0, -180.0)
+    viewer.state.cut_enabled = True
+    viewer.state.cut_mode = 'Advanced'
+    # arccos(1/sqrt(1.25)) and pi/2 give the unit normal (0, 0.447, 0.894);
+    # cut_depth places the plane just past the cube centre on the +normal side.
+    import numpy as np
+    viewer.state.cut_tilt = float(np.arccos(1.0 / np.sqrt(1.25)))
+    viewer.state.cut_rotation = float(np.pi / 2)
+    viewer.state.cut_depth = 0.524088
     viewer._vispy_widget.view.camera.azimuth += 180
 
 

--- a/glue_vispy_viewers/volume/tests/scenes.py
+++ b/glue_vispy_viewers/volume/tests/scenes.py
@@ -112,6 +112,26 @@ def volume_clip_off(viewer):
     viewer.state.clip_data = False
 
 
+def volume_cutting_plane(viewer):
+    """L1448 with a plasma colormap and a diagonal cutting plane.
+
+    The plane is set to ``ax + by + cz + d = 0`` with ``(a, b, c, d) =
+    (1, 1, 0, -80)``, which slices the cube diagonally across the
+    velocity/x axis. The render should show roughly half the cube
+    revealed; setting ``cutting_plane=None`` and re-rendering would
+    bring the rest back. Used to verify that the cutting-plane uniforms
+    reach the GPU and that the disabled/enabled toggle path is wired up.
+    """
+    import matplotlib.pyplot as plt
+    layer = viewer.state.layers[0]
+    layer.alpha = 1.0
+    layer.color_mode = 'Linear'
+    layer.cmap = plt.cm.plasma
+    layer.v_min = -0.7
+    layer.v_max = 2.74
+    viewer.state.cutting_plane = (1.0, 1.0, 0.0, -80.0)
+
+
 def volume_with_scatter_overlay(app, viewer, vol_data, scatter_data):
     """Volume rendering with a 1D scatter overlay."""
     basic_volume(viewer)

--- a/glue_vispy_viewers/volume/tests/test_viewer_state.py
+++ b/glue_vispy_viewers/volume/tests/test_viewer_state.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..viewer_state import (Vispy3DVolumeViewerState, cutting_plane_from_state,
-                            _CUBE_CENTER)
+                            cutting_plane_polygon, _CUBE_CENTER)
 
 
 def test_default_disabled():
@@ -60,6 +60,71 @@ def test_advanced_normal_is_unit_vector():
     state.cut_depth = 0.5
     a, b, c, _ = cutting_plane_from_state(state)
     assert round(a * a + b * b + c * c, 6) == 1.0
+
+
+def _set_extent(state, x=(0., 10.), y=(0., 10.), z=(0., 10.)):
+    state.x_min, state.x_max = x
+    state.y_min, state.y_max = y
+    state.z_min, state.z_max = z
+
+
+def test_polygon_none_when_disabled():
+    state = Vispy3DVolumeViewerState()
+    _set_extent(state)
+    assert cutting_plane_polygon(state) is None
+
+
+def test_polygon_simple_z_is_horizontal_square():
+    # depth=0.5, axis Z -> plane at z = (z_min+z_max)/2; intersects the
+    # cube as the four mid-z corners of a horizontal square.
+    state = Vispy3DVolumeViewerState()
+    _set_extent(state)
+    state.cut_enabled = True
+    state.cut_mode = 'Simple'
+    state.cut_axis = 'Z'
+    state.cut_depth = 0.5
+    poly = cutting_plane_polygon(state)
+    assert poly.shape == (4, 3)
+    assert np.allclose(poly[:, 2], 5.0)
+    # The four corners should be the cube's x/y extremes at z=5
+    xy = sorted(map(tuple, np.round(poly[:, :2], 6).tolist()))
+    assert xy == [(0., 0.), (0., 10.), (10., 0.), (10., 10.)]
+
+
+def test_polygon_depth_endpoints_miss_the_box():
+    state = Vispy3DVolumeViewerState()
+    _set_extent(state)
+    state.cut_enabled = True
+    state.cut_mode = 'Simple'
+    state.cut_axis = 'Z'
+    state.cut_depth = 0.0
+    assert cutting_plane_polygon(state) is None
+    state.cut_depth = 1.0
+    assert cutting_plane_polygon(state) is None
+
+
+def test_polygon_tilted_lies_on_plane():
+    state = Vispy3DVolumeViewerState()
+    _set_extent(state, x=(-1., 1.), y=(-2., 2.), z=(0., 4.))
+    state.cut_enabled = True
+    state.cut_mode = 'Advanced'
+    state.cut_tilt = 0.7
+    state.cut_rotation = 1.3
+    state.cut_depth = 0.5
+    poly = cutting_plane_polygon(state)
+    assert poly is not None and poly.shape[0] >= 3
+    # Each vertex satisfies the plane equation in data coords; the cube
+    # centre lies on the plane at depth 0.5, so signed distance from
+    # centre equals (vertex - centre) . n.
+    centre = np.array([0., 0., 2.])
+    a = np.sin(state.cut_tilt) * np.cos(state.cut_rotation)
+    b = np.sin(state.cut_tilt) * np.sin(state.cut_rotation)
+    c = np.cos(state.cut_tilt)
+    # Convert shader normal (in v_position coords) to data-coord normal
+    # by dividing by the per-axis scale.
+    n_data = np.array([a / 1.0, b / 2.0, c / 2.0])  # scales = range/CUBE_EXTENT cancel
+    for p in poly:
+        assert abs(np.dot(p - centre, n_data)) < 1e-6
 
 
 def test_advanced_known_orientation():

--- a/glue_vispy_viewers/volume/tests/test_viewer_state.py
+++ b/glue_vispy_viewers/volume/tests/test_viewer_state.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..viewer_state import (Vispy3DVolumeViewerState, cutting_plane_from_state,
-                            _CUBE_CENTER, _CUBE_HALF_DIAGONAL)
+                            _CUBE_CENTER)
 
 
 def test_default_disabled():

--- a/glue_vispy_viewers/volume/tests/test_viewer_state.py
+++ b/glue_vispy_viewers/volume/tests/test_viewer_state.py
@@ -155,9 +155,9 @@ def test_flip_cut_is_an_involution():
     assert np.allclose(cutting_plane_from_state(state), before)
 
 
-def test_flip_cut_switches_simple_to_advanced():
-    # An axis-aligned Simple cut can only keep the minus-axis side, so a flip
-    # converts to the equivalent free orientation and switches to Advanced.
+def test_flip_cut_in_simple_mode_stays_simple():
+    # The flip works the same in Simple mode: it negates the plane (keeping the
+    # opposite axis side) without leaving Simple mode or touching the axis.
     state = Vispy3DVolumeViewerState()
     state.cut_enabled = True
     state.cut_mode = 'Simple'
@@ -165,8 +165,23 @@ def test_flip_cut_switches_simple_to_advanced():
     state.cut_depth = 0.3
     a, b, c, d = cutting_plane_from_state(state)
     state.flip_cut()
-    assert state.cut_mode == 'Advanced'
+    assert state.cut_mode == 'Simple'
+    assert state.cut_axis == 'Z'
     assert np.allclose(cutting_plane_from_state(state), [-a, -b, -c, -d])
+
+
+def test_flip_cut_leaves_orientation_unchanged():
+    # The flip only toggles cut_flip; tilt, rotation, depth and mode stay put.
+    state = Vispy3DVolumeViewerState()
+    state.cut_enabled = True
+    state.cut_mode = 'Advanced'
+    state.cut_tilt = 0.7
+    state.cut_rotation = 1.3
+    state.cut_depth = 0.3
+    state.flip_cut()
+    assert state.cut_flip is True
+    assert (state.cut_mode, state.cut_tilt, state.cut_rotation, state.cut_depth) == \
+        ('Advanced', 0.7, 1.3, 0.3)
 
 
 def test_advanced_known_orientation():

--- a/glue_vispy_viewers/volume/tests/test_viewer_state.py
+++ b/glue_vispy_viewers/volume/tests/test_viewer_state.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..viewer_state import (Vispy3DVolumeViewerState, cutting_plane_from_state,
-                            cutting_plane_polygon, _CUBE_CENTER)
+                            cutting_plane_polygon, _cube_extent)
 
 
 def test_default_disabled():
@@ -19,7 +19,7 @@ def test_simple_axis_z():
     a, b, c, d = cutting_plane_from_state(state)
     assert (a, b) == (0.0, 0.0)
     assert c == 1.0
-    assert d == -_CUBE_CENTER  # plane at z = 128
+    assert d == -_cube_extent(state) / 2  # plane through the cube centre
 
 
 def test_simple_axis_x_and_y():
@@ -42,9 +42,9 @@ def test_depth_endpoints_are_outside_cube():
     state.cut_axis = 'Z'
     state.cut_depth = 0.0
     _, _, _, d_no_cut = cutting_plane_from_state(state)
-    # depth=0 -> plane just past the +normal corner of the cube; the
-    # plane crosses z = -d, which for normal +z must lie beyond z=256.
-    assert -d_no_cut > 256
+    # depth=0 -> plane just past the +normal corner of the cube; the plane
+    # crosses z = -d, which for normal +z must lie beyond the cube extent.
+    assert -d_no_cut > _cube_extent(state)
     state.cut_depth = 1.0
     _, _, _, d_all_cut = cutting_plane_from_state(state)
     # depth=1 -> plane just past the -normal corner: z = -d < 0.
@@ -187,11 +187,25 @@ def test_flip_cut_leaves_orientation_unchanged():
 def _data_kept_threshold(state):
     # For an X-axis cut, return (threshold, keep_low) describing the kept
     # half-space in data coordinates: data-x < threshold when keep_low.
-    from ..viewer_state import _CUBE_EXTENT
     a, b, c, d = cutting_plane_from_state(state)
-    A = a * _CUBE_EXTENT / (state.x_max - state.x_min)
+    A = a * _cube_extent(state) / (state.x_max - state.x_min)
     D = d - A * state.x_min
     return -D / A, A > 0
+
+
+def test_plane_scales_with_resolution():
+    # The shader cube spans 0..resolution, so a centred cut must land at
+    # resolution / 2 rather than a hard-coded 256-based value.
+    for resolution in (64, 256, 512):
+        state = Vispy3DVolumeViewerState()
+        state.resolution = resolution
+        state.cut_enabled = True
+        state.cut_mode = 'Simple'
+        state.cut_axis = 'Z'
+        state.cut_depth = 0.5
+        _, _, c, d = cutting_plane_from_state(state)
+        assert c == 1.0
+        assert d == -resolution / 2  # plane at z = resolution / 2
 
 
 def test_flipping_axis_limit_keeps_same_data_side():
@@ -221,4 +235,4 @@ def test_advanced_known_orientation():
     state.cut_depth = 0.5
     a, b, c, d = cutting_plane_from_state(state)
     assert (round(a, 6), round(b, 6), round(c, 6)) == (1.0, 0.0, 0.0)
-    assert round(d, 6) == -_CUBE_CENTER
+    assert round(d, 6) == -_cube_extent(state) / 2

--- a/glue_vispy_viewers/volume/tests/test_viewer_state.py
+++ b/glue_vispy_viewers/volume/tests/test_viewer_state.py
@@ -184,6 +184,33 @@ def test_flip_cut_leaves_orientation_unchanged():
         ('Advanced', 0.7, 1.3, 0.3)
 
 
+def _data_kept_threshold(state):
+    # For an X-axis cut, return (threshold, keep_low) describing the kept
+    # half-space in data coordinates: data-x < threshold when keep_low.
+    from ..viewer_state import _CUBE_EXTENT
+    a, b, c, d = cutting_plane_from_state(state)
+    A = a * _CUBE_EXTENT / (state.x_max - state.x_min)
+    D = d - A * state.x_min
+    return -D / A, A > 0
+
+
+def test_flipping_axis_limit_keeps_same_data_side():
+    # Flipping an axis limit mirrors the display, but the cut should stay on
+    # the same physical data so it mirrors together with the bounding box
+    # rather than snapping to the opposite data when the texture re-slices.
+    state = Vispy3DVolumeViewerState()
+    _set_extent(state)
+    state.cut_enabled = True
+    state.cut_mode = 'Simple'
+    state.cut_axis = 'X'
+    state.cut_depth = 0.3  # off-centre so the kept side is directional
+    before = _data_kept_threshold(state)
+    state.flip_x()
+    after = _data_kept_threshold(state)
+    assert np.allclose(before[0], after[0])
+    assert before[1] == after[1]
+
+
 def test_advanced_known_orientation():
     # Tilt = pi/2, rotation = 0 -> normal pointing +x; same as Simple X.
     state = Vispy3DVolumeViewerState()

--- a/glue_vispy_viewers/volume/tests/test_viewer_state.py
+++ b/glue_vispy_viewers/volume/tests/test_viewer_state.py
@@ -127,6 +127,48 @@ def test_polygon_tilted_lies_on_plane():
         assert abs(np.dot(p - centre, n_data)) < 1e-6
 
 
+def test_flip_cut_negates_the_plane():
+    # Flipping swaps the kept and removed sides in place, i.e. it negates the
+    # whole plane equation (a, b, c, d) -> (-a, -b, -c, -d).
+    state = Vispy3DVolumeViewerState()
+    state.cut_enabled = True
+    state.cut_mode = 'Advanced'
+    state.cut_tilt = 0.7
+    state.cut_rotation = 1.3
+    state.cut_depth = 0.3
+    a, b, c, d = cutting_plane_from_state(state)
+    state.flip_cut()
+    a2, b2, c2, d2 = cutting_plane_from_state(state)
+    assert np.allclose([a2, b2, c2, d2], [-a, -b, -c, -d])
+
+
+def test_flip_cut_is_an_involution():
+    state = Vispy3DVolumeViewerState()
+    state.cut_enabled = True
+    state.cut_mode = 'Advanced'
+    state.cut_tilt = 0.7
+    state.cut_rotation = 1.3
+    state.cut_depth = 0.3
+    before = cutting_plane_from_state(state)
+    state.flip_cut()
+    state.flip_cut()
+    assert np.allclose(cutting_plane_from_state(state), before)
+
+
+def test_flip_cut_switches_simple_to_advanced():
+    # An axis-aligned Simple cut can only keep the minus-axis side, so a flip
+    # converts to the equivalent free orientation and switches to Advanced.
+    state = Vispy3DVolumeViewerState()
+    state.cut_enabled = True
+    state.cut_mode = 'Simple'
+    state.cut_axis = 'Z'
+    state.cut_depth = 0.3
+    a, b, c, d = cutting_plane_from_state(state)
+    state.flip_cut()
+    assert state.cut_mode == 'Advanced'
+    assert np.allclose(cutting_plane_from_state(state), [-a, -b, -c, -d])
+
+
 def test_advanced_known_orientation():
     # Tilt = pi/2, rotation = 0 -> normal pointing +x; same as Simple X.
     state = Vispy3DVolumeViewerState()

--- a/glue_vispy_viewers/volume/tests/test_viewer_state.py
+++ b/glue_vispy_viewers/volume/tests/test_viewer_state.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+from ..viewer_state import (Vispy3DVolumeViewerState, cutting_plane_from_state,
+                            _CUBE_CENTER, _CUBE_HALF_DIAGONAL)
+
+
+def test_default_disabled():
+    state = Vispy3DVolumeViewerState()
+    assert state.cut_enabled is False
+    assert cutting_plane_from_state(state) is None
+
+
+def test_simple_axis_z():
+    state = Vispy3DVolumeViewerState()
+    state.cut_enabled = True
+    state.cut_mode = 'Simple'
+    state.cut_axis = 'Z'
+    state.cut_depth = 0.5  # plane through cube centre
+    a, b, c, d = cutting_plane_from_state(state)
+    assert (a, b) == (0.0, 0.0)
+    assert c == 1.0
+    assert d == -_CUBE_CENTER  # plane at z = 128
+
+
+def test_simple_axis_x_and_y():
+    state = Vispy3DVolumeViewerState()
+    state.cut_enabled = True
+    state.cut_mode = 'Simple'
+    state.cut_depth = 0.5
+    state.cut_axis = 'X'
+    a, b, c, _ = cutting_plane_from_state(state)
+    assert (round(a, 6), round(b, 6), round(c, 6)) == (1.0, 0.0, 0.0)
+    state.cut_axis = 'Y'
+    a, b, c, _ = cutting_plane_from_state(state)
+    assert (round(a, 6), round(b, 6), round(c, 6)) == (0.0, 1.0, 0.0)
+
+
+def test_depth_endpoints_are_outside_cube():
+    state = Vispy3DVolumeViewerState()
+    state.cut_enabled = True
+    state.cut_mode = 'Simple'
+    state.cut_axis = 'Z'
+    state.cut_depth = 0.0
+    _, _, _, d_no_cut = cutting_plane_from_state(state)
+    # depth=0 -> plane just past the +normal corner of the cube; the
+    # plane crosses z = -d, which for normal +z must lie beyond z=256.
+    assert -d_no_cut > 256
+    state.cut_depth = 1.0
+    _, _, _, d_all_cut = cutting_plane_from_state(state)
+    # depth=1 -> plane just past the -normal corner: z = -d < 0.
+    assert -d_all_cut < 0
+
+
+def test_advanced_normal_is_unit_vector():
+    state = Vispy3DVolumeViewerState()
+    state.cut_enabled = True
+    state.cut_mode = 'Advanced'
+    state.cut_tilt = 0.7
+    state.cut_rotation = 1.3
+    state.cut_depth = 0.5
+    a, b, c, _ = cutting_plane_from_state(state)
+    assert round(a * a + b * b + c * c, 6) == 1.0
+
+
+def test_advanced_known_orientation():
+    # Tilt = pi/2, rotation = 0 -> normal pointing +x; same as Simple X.
+    state = Vispy3DVolumeViewerState()
+    state.cut_enabled = True
+    state.cut_mode = 'Advanced'
+    state.cut_tilt = float(np.pi / 2)
+    state.cut_rotation = 0.0
+    state.cut_depth = 0.5
+    a, b, c, d = cutting_plane_from_state(state)
+    assert (round(a, 6), round(b, 6), round(c, 6)) == (1.0, 0.0, 0.0)
+    assert round(d, 6) == -_CUBE_CENTER

--- a/glue_vispy_viewers/volume/tests/test_visual.py
+++ b/glue_vispy_viewers/volume/tests/test_visual.py
@@ -45,6 +45,35 @@ def test_flip_axis_limit_keeps_volume_visible():
         viewer.close()
 
 
+@pytest.mark.skipif(not HAS_VISUAL_TEST_DEPS,
+                    reason="requires Pillow, vispy[glfw] and a display")
+def test_cutting_plane_works_at_non_default_resolution():
+    # The cutting plane lives in the shader cube which spans 0..resolution, so
+    # a centred cut must remove roughly half the volume at any resolution --
+    # not only the default 256. Also exercise changing the resolution while
+    # the cut is active, which must refresh the plane uniforms.
+    data = scenes.blob_data()
+    _, viewer = _make_viewer(data)
+    scenes.basic_volume(viewer)
+    viewer.state.cut_enabled = True
+    viewer.state.cut_mode = 'Simple'
+    viewer.state.cut_axis = 'Z'
+    viewer.state.cut_depth = 0.5
+    try:
+        # Switching resolution with the cut active must refresh the plane
+        # uniforms; at each resolution the centred cut should still remove a
+        # meaningful chunk of the volume.
+        for resolution in (64, 256):
+            viewer.state.resolution = resolution
+            viewer.state.cut_enabled = False
+            uncut = _rendered_data_fraction(viewer)
+            viewer.state.cut_enabled = True
+            cut = _rendered_data_fraction(viewer)
+            assert uncut - cut > 0.05, (resolution, uncut, cut)
+    finally:
+        viewer.close()
+
+
 @visual_test(tolerance=5)
 def test_visual_volume3d_basic():
     data = scenes.blob_data()

--- a/glue_vispy_viewers/volume/tests/test_visual.py
+++ b/glue_vispy_viewers/volume/tests/test_visual.py
@@ -1,7 +1,11 @@
+import numpy as np
+import pytest
+
 from glue.core import DataCollection
 from glue.core.application_base import Application
 
-from ...tests.helpers import inverted_glue_colors, set_canvas_size, visual_test
+from ...tests.helpers import (HAS_VISUAL_TEST_DEPS, inverted_glue_colors,
+                              set_canvas_size, visual_test)
 from ..volume_viewer import SimpleVispyVolumeViewer
 from . import scenes
 
@@ -11,6 +15,34 @@ def _make_viewer(data, extra_data=()):
     viewer = app.new_data_viewer(SimpleVispyVolumeViewer, data=data)
     set_canvas_size(viewer, 500, 500)
     return app, viewer
+
+
+def _rendered_data_fraction(viewer):
+    """Fraction of canvas pixels that differ from the background corner."""
+    img = np.asarray(viewer._vispy_widget.canvas.render())[..., :3].astype(int)
+    background = img[0, 0]
+    return (np.abs(img - background).sum(-1) > 10).mean()
+
+
+@pytest.mark.skipif(not HAS_VISUAL_TEST_DEPS,
+                    reason="requires Pillow, vispy[glfw] and a display")
+def test_flip_axis_limit_keeps_volume_visible():
+    # Regression test: flipping an axis limit (so x_min > x_max) gives the
+    # limit transform a negative scale, which used to leave the clip box with
+    # an inverted axis (min > max) so the shader clipped the whole volume away.
+    # The data should stay visible after flipping each axis in turn.
+    data = scenes.blob_data()
+    _, viewer = _make_viewer(data)
+    scenes.basic_volume(viewer)
+    assert viewer.state.clip_data
+    baseline = _rendered_data_fraction(viewer)
+    assert baseline > 0.1
+    try:
+        for flip in (viewer.state.flip_x, viewer.state.flip_y, viewer.state.flip_z):
+            flip()
+            assert _rendered_data_fraction(viewer) > 0.5 * baseline
+    finally:
+        viewer.close()
 
 
 @visual_test(tolerance=5)

--- a/glue_vispy_viewers/volume/tests/test_visual.py
+++ b/glue_vispy_viewers/volume/tests/test_visual.py
@@ -43,6 +43,18 @@ def test_visual_volume3d_native_aspect():
 
 
 @visual_test(tolerance=5)
+def test_visual_volume3d_cutting_plane():
+    # Exercises the cutting plane uniforms via the L1448 cube. Sets a
+    # diagonal cut so a render with the plane disabled (or with the
+    # uniforms wrong) would look obviously different from the baseline.
+    with inverted_glue_colors():
+        data = scenes.l1448_data()
+        _, viewer = _make_viewer(data)
+        scenes.volume_cutting_plane(viewer)
+        return viewer
+
+
+@visual_test(tolerance=5)
 def test_visual_volume3d_subset():
     data = scenes.blob_data()
     app, viewer = _make_viewer(data)

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -3,7 +3,7 @@ from echo import CallbackProperty, SelectionCallbackProperty
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 
-__all__ = ['Vispy3DVolumeViewerState']
+__all__ = ['Vispy3DVolumeViewerState', 'cutting_plane_polygon']
 
 
 # In the volume fragment shader, v_position spans 0..u_shape on each axis,
@@ -47,6 +47,78 @@ def cutting_plane_from_state(state):
     offset = _CUBE_HALF_DIAGONAL * (1.0 - 2.0 * state.cut_depth)
     d = -(a + b + c) * _CUBE_CENTER - offset
     return float(a), float(b), float(c), float(d)
+
+
+# Edge list for the 8-corner cube, where corner index ``i`` is
+# (xmin if bit0 else xmax, ymin if bit1 else ymax, zmin if bit2 else zmax).
+_CUBE_EDGES = ((0, 1), (2, 3), (4, 5), (6, 7),
+               (0, 2), (1, 3), (4, 6), (5, 7),
+               (0, 4), (1, 5), (2, 6), (3, 7))
+
+
+def cutting_plane_polygon(state):
+    """Polygon where the cutting plane intersects the data bounding box.
+
+    Returns an ``(N, 3)`` array of vertices in data coordinates ordered
+    around the centroid (suitable for drawing as a closed line strip),
+    or ``None`` if the plane misses the box (or the state is disabled).
+    """
+    plane = cutting_plane_from_state(state)
+    if plane is None:
+        return None
+
+    # Convert the shader plane (which lives in 0..256 v_position coords)
+    # into data coords. With ``v_k = (k - k_min) * 256 / (k_max - k_min)``
+    # the equation ``a*vx + b*vy + c*vz + d = 0`` becomes
+    # ``A*x + B*y + C*z + D = 0`` with the scaling below.
+    a, b, c, d = plane
+    rng_x = state.x_max - state.x_min
+    rng_y = state.y_max - state.y_min
+    rng_z = state.z_max - state.z_min
+    if rng_x == 0 or rng_y == 0 or rng_z == 0:
+        return None
+    A = a * _CUBE_EXTENT / rng_x
+    B = b * _CUBE_EXTENT / rng_y
+    C = c * _CUBE_EXTENT / rng_z
+    D = d - A * state.x_min - B * state.y_min - C * state.z_min
+    n = np.array([A, B, C])
+
+    corners = np.array([(state.x_min if (i & 1) == 0 else state.x_max,
+                         state.y_min if (i & 2) == 0 else state.y_max,
+                         state.z_min if (i & 4) == 0 else state.z_max)
+                        for i in range(8)])
+    side = corners @ n + D
+
+    points = []
+    for i, j in _CUBE_EDGES:
+        s0, s1 = side[i], side[j]
+        if s0 * s1 < 0:
+            t = s0 / (s0 - s1)
+            points.append(corners[i] + t * (corners[j] - corners[i]))
+        elif s0 == 0:
+            points.append(corners[i])
+
+    if len(points) < 3:
+        return None
+
+    points = np.asarray(points)
+    centroid = points.mean(axis=0)
+    # Build a 2D basis on the plane to sort vertices around the centroid.
+    ref = np.array([1.0, 0.0, 0.0]) if abs(n[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+    u = np.cross(n, ref)
+    u /= np.linalg.norm(u)
+    v = np.cross(n, u)
+    diffs = points - centroid
+    angles = np.arctan2(diffs @ v, diffs @ u)
+    # Deduplicate vertices that coincide (e.g. when the plane passes through a
+    # cube corner two edges report the same point).
+    order = np.argsort(angles)
+    ordered = points[order]
+    keep = [ordered[0]]
+    for p in ordered[1:]:
+        if np.linalg.norm(p - keep[-1]) > 1e-6:
+            keep.append(p)
+    return np.asarray(keep)
 
 
 class Vispy3DVolumeViewerState(VolumeViewerState3D):

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -1,5 +1,5 @@
 import numpy as np
-from echo import CallbackProperty, SelectionCallbackProperty, delay_callback
+from echo import CallbackProperty, SelectionCallbackProperty
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 
@@ -46,6 +46,10 @@ def cutting_plane_from_state(state):
     c = np.cos(tilt)
     offset = _CUBE_HALF_DIAGONAL * (1.0 - 2.0 * state.cut_depth)
     d = -(a + b + c) * _CUBE_CENTER - offset
+    if state.cut_flip:
+        # Negate the whole plane equation: the same geometric plane, with the
+        # kept and removed half-spaces swapped.
+        a, b, c, d = -a, -b, -c, -d
     return float(a), float(b), float(c), float(d)
 
 
@@ -142,26 +146,18 @@ class Vispy3DVolumeViewerState(VolumeViewerState3D):
     cut_rotation = CallbackProperty(
         0.0, docstring='Azimuthal angle of the plane normal, radians (0..2*pi).')
     cut_depth = CallbackProperty(0.5, docstring='Depth of the cut, 0 (no cut) to 1 (full cut).')
+    cut_flip = CallbackProperty(
+        False, docstring='Whether to show the opposite side of the cutting plane.')
 
     def flip_cut(self):
-        """Swap the shown and clipped sides of the cutting plane in place.
+        """Swap which side of the cutting plane is shown versus clipped.
 
-        Negates the plane normal (``tilt -> pi - tilt``,
-        ``rotation -> rotation + pi``) and mirrors the depth
-        (``depth -> 1 - depth``) so the plane stays put while the kept and
-        removed regions swap. An axis-aligned Simple-mode cut can only ever
-        keep the minus-axis side, so flipping converts the current axis to
-        the equivalent free orientation and switches to Advanced mode.
+        Toggles :attr:`cut_flip`, which negates the plane equation in
+        ``cutting_plane_from_state`` so the kept and removed regions swap
+        without moving the plane or touching the tilt, rotation, depth or
+        mode. This works the same in Simple and Advanced mode.
         """
-        with delay_callback(self, 'cut_mode', 'cut_tilt', 'cut_rotation', 'cut_depth'):
-            if self.cut_mode == 'Simple':
-                tilt, rotation = _axis_angles(self.cut_axis)
-                self.cut_mode = 'Advanced'
-            else:
-                tilt, rotation = self.cut_tilt, self.cut_rotation
-            self.cut_tilt = float(np.pi - tilt)
-            self.cut_rotation = float((rotation + np.pi) % (2.0 * np.pi))
-            self.cut_depth = 1.0 - self.cut_depth
+        self.cut_flip = not self.cut_flip
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -67,7 +67,8 @@ class Vispy3DVolumeViewerState(VolumeViewerState3D):
         2, choices=['X', 'Y', 'Z'],
         docstring='Axis perpendicular to the cutting plane in Simple mode.')
     cut_tilt = CallbackProperty(0.0, docstring='Polar angle of the plane normal, radians (0..pi).')
-    cut_rotation = CallbackProperty(0.0, docstring='Azimuthal angle of the plane normal, radians (0..2*pi).')
+    cut_rotation = CallbackProperty(
+        0.0, docstring='Azimuthal angle of the plane normal, radians (0..2*pi).')
     cut_depth = CallbackProperty(0.5, docstring='Depth of the cut, 0 (no cut) to 1 (full cut).')
 
     def __init__(self, **kwargs):

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -1,8 +1,52 @@
-from echo import CallbackProperty
+import numpy as np
+from echo import CallbackProperty, SelectionCallbackProperty
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 
 __all__ = ['Vispy3DVolumeViewerState']
+
+
+# In the volume fragment shader, v_position spans 0..u_shape on each axis,
+# with u_shape = (256, 256, 256) regardless of the underlying data shape.
+# Cutting plane parameters are computed relative to this cube.
+_CUBE_EXTENT = 256.0
+_CUBE_CENTER = _CUBE_EXTENT / 2.0
+_CUBE_HALF_DIAGONAL = (3.0 ** 0.5) * _CUBE_CENTER
+
+
+def _axis_angles(axis):
+    """Return ``(tilt, rotation)`` in radians for an axis-aligned cut.
+
+    The normal is +x, +y or +z; the cube center sits on the kept side.
+    """
+    if axis == 'X':
+        return np.pi / 2, 0.0
+    if axis == 'Y':
+        return np.pi / 2, np.pi / 2
+    return 0.0, 0.0   # 'Z'
+
+
+def cutting_plane_from_state(state):
+    """Return the shader (a, b, c, d) tuple, or ``None`` if disabled.
+
+    The cube extends 0..256 in each shader coordinate. The plane's signed
+    distance from the cube centre is moved linearly between
+    ``+_CUBE_HALF_DIAGONAL`` (depth=0, plane outside on the +normal side,
+    nothing cut) and ``-_CUBE_HALF_DIAGONAL`` (depth=1, plane outside on
+    the -normal side, everything cut).
+    """
+    if not state.cut_enabled:
+        return None
+    if state.cut_mode == 'Simple':
+        tilt, rotation = _axis_angles(state.cut_axis)
+    else:
+        tilt, rotation = state.cut_tilt, state.cut_rotation
+    a = np.sin(tilt) * np.cos(rotation)
+    b = np.sin(tilt) * np.sin(rotation)
+    c = np.cos(tilt)
+    offset = _CUBE_HALF_DIAGONAL * (1.0 - 2.0 * state.cut_depth)
+    d = -(a + b + c) * _CUBE_CENTER - offset
+    return float(a), float(b), float(c), float(d)
 
 
 class Vispy3DVolumeViewerState(VolumeViewerState3D):
@@ -15,6 +59,22 @@ class Vispy3DVolumeViewerState(VolumeViewerState3D):
     cross-frontend concepts they can be lifted into glue-core.
     """
 
-    # Cutting plane defined as ``a*x + b*y + c*z + d = 0``; the tuple
-    # holds ``(a, b, c, d)``. ``None`` disables the cut.
-    cutting_plane = CallbackProperty(None)
+    cut_enabled = CallbackProperty(False, docstring='Whether the cutting plane is active.')
+    cut_mode = SelectionCallbackProperty(
+        0, choices=['Simple', 'Advanced'],
+        docstring='Simple (axis-aligned) or Advanced (free orientation).')
+    cut_axis = SelectionCallbackProperty(
+        2, choices=['X', 'Y', 'Z'],
+        docstring='Axis perpendicular to the cutting plane in Simple mode.')
+    cut_tilt = CallbackProperty(0.0, docstring='Polar angle of the plane normal, radians (0..pi).')
+    cut_rotation = CallbackProperty(0.0, docstring='Azimuthal angle of the plane normal, radians (0..2*pi).')
+    cut_depth = CallbackProperty(0.5, docstring='Depth of the cut, 0 (no cut) to 1 (full cut).')
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # SelectionCallbackProperty stores choices per-instance via a WeakKeyDictionary
+        # populated lazily on first ``get_choices`` lookup. Force the dictionary to be
+        # populated now so the choices are bound to the instance (rather than only to
+        # the class) and survive a round-trip through ``__setgluestate__``.
+        Vispy3DVolumeViewerState.cut_mode.set_choices(self, ['Simple', 'Advanced'])
+        Vispy3DVolumeViewerState.cut_axis.set_choices(self, ['X', 'Y', 'Z'])

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -46,6 +46,15 @@ def cutting_plane_from_state(state):
     c = np.cos(tilt)
     offset = _CUBE_HALF_DIAGONAL * (1.0 - 2.0 * state.cut_depth)
     d = -(a + b + c) * _CUBE_CENTER - offset
+    # Flipping an axis limit (max < min) reverses the data along that axis in
+    # the volume texture, so reflect the plane across the axis (v -> 256 - v)
+    # to keep the cut on the same data side as the bounding box and axis ticks.
+    if state.x_max < state.x_min:
+        a, d = -a, d + _CUBE_EXTENT * a
+    if state.y_max < state.y_min:
+        b, d = -b, d + _CUBE_EXTENT * b
+    if state.z_max < state.z_min:
+        c, d = -c, d + _CUBE_EXTENT * c
     if state.cut_flip:
         # Negate the whole plane equation: the same geometric plane, with the
         # kept and removed half-spaces swapped.

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -1,15 +1,20 @@
-import warnings
+from echo import CallbackProperty
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 
 __all__ = ['Vispy3DVolumeViewerState']
 
-warnings.warn(
-    "Importing Vispy3DVolumeViewerState from glue_vispy_viewers.volume.viewer_state is deprecated. "
-    "Please import VolumeViewerState3D from glue.viewers.volume3d.viewer_state instead.",
-    DeprecationWarning,
-    stacklevel=2
-)
 
-# Re-export for backwards compatibility
-Vispy3DVolumeViewerState = VolumeViewerState3D
+class Vispy3DVolumeViewerState(VolumeViewerState3D):
+    """Volume viewer state with vispy-only extensions.
+
+    Subclasses ``glue.viewers.volume3d.viewer_state.VolumeViewerState3D``
+    and adds attributes that only make sense for the vispy-based volume
+    renderer, so they aren't visible from non-vispy frontends (notably
+    ipyvolume) which would otherwise ignore them. If/when those become
+    cross-frontend concepts they can be lifted into glue-core.
+    """
+
+    # Cutting plane defined as ``a*x + b*y + c*z + d = 0``; the tuple
+    # holds ``(a, b, c, d)``. ``None`` disables the cut.
+    cutting_plane = CallbackProperty(None)

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -6,12 +6,16 @@ from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 __all__ = ['Vispy3DVolumeViewerState', 'cutting_plane_polygon']
 
 
-# In the volume fragment shader, v_position spans 0..u_shape on each axis,
-# with u_shape = (256, 256, 256) regardless of the underlying data shape.
-# Cutting plane parameters are computed relative to this cube.
-_CUBE_EXTENT = 256.0
-_CUBE_CENTER = _CUBE_EXTENT / 2.0
-_CUBE_HALF_DIAGONAL = (3.0 ** 0.5) * _CUBE_CENTER
+def _cube_extent(state):
+    """Side length of the shader cube the cutting plane is defined in.
+
+    The volume fragment shader's ``v_position`` spans ``0..u_shape`` on each
+    axis, and ``u_shape`` is ``(resolution,) * 3`` (the fixed-resolution
+    buffer size, independent of the underlying data shape). The cutting plane
+    parameters are therefore computed relative to a cube whose side equals the
+    current resolution rather than a fixed size.
+    """
+    return float(state.resolution)
 
 
 def _axis_angles(axis):
@@ -29,11 +33,11 @@ def _axis_angles(axis):
 def cutting_plane_from_state(state):
     """Return the shader (a, b, c, d) tuple, or ``None`` if disabled.
 
-    The cube extends 0..256 in each shader coordinate. The plane's signed
-    distance from the cube centre is moved linearly between
-    ``+_CUBE_HALF_DIAGONAL`` (depth=0, plane outside on the +normal side,
-    nothing cut) and ``-_CUBE_HALF_DIAGONAL`` (depth=1, plane outside on
-    the -normal side, everything cut).
+    The cube extends 0..resolution in each shader coordinate. The plane's
+    signed distance from the cube centre is moved linearly between
+    ``+half_diagonal`` (depth=0, plane outside on the +normal side, nothing
+    cut) and ``-half_diagonal`` (depth=1, plane outside on the -normal side,
+    everything cut).
     """
     if not state.cut_enabled:
         return None
@@ -41,20 +45,23 @@ def cutting_plane_from_state(state):
         tilt, rotation = _axis_angles(state.cut_axis)
     else:
         tilt, rotation = state.cut_tilt, state.cut_rotation
+    extent = _cube_extent(state)
+    center = extent / 2.0
+    half_diagonal = (3.0 ** 0.5) * center
     a = np.sin(tilt) * np.cos(rotation)
     b = np.sin(tilt) * np.sin(rotation)
     c = np.cos(tilt)
-    offset = _CUBE_HALF_DIAGONAL * (1.0 - 2.0 * state.cut_depth)
-    d = -(a + b + c) * _CUBE_CENTER - offset
+    offset = half_diagonal * (1.0 - 2.0 * state.cut_depth)
+    d = -(a + b + c) * center - offset
     # Flipping an axis limit (max < min) reverses the data along that axis in
-    # the volume texture, so reflect the plane across the axis (v -> 256 - v)
+    # the volume texture, so reflect the plane across the axis (v -> extent - v)
     # to keep the cut on the same data side as the bounding box and axis ticks.
     if state.x_max < state.x_min:
-        a, d = -a, d + _CUBE_EXTENT * a
+        a, d = -a, d + extent * a
     if state.y_max < state.y_min:
-        b, d = -b, d + _CUBE_EXTENT * b
+        b, d = -b, d + extent * b
     if state.z_max < state.z_min:
-        c, d = -c, d + _CUBE_EXTENT * c
+        c, d = -c, d + extent * c
     if state.cut_flip:
         # Negate the whole plane equation: the same geometric plane, with the
         # kept and removed half-spaces swapped.
@@ -80,19 +87,20 @@ def cutting_plane_polygon(state):
     if plane is None:
         return None
 
-    # Convert the shader plane (which lives in 0..256 v_position coords)
-    # into data coords. With ``v_k = (k - k_min) * 256 / (k_max - k_min)``
+    # Convert the shader plane (which lives in 0..extent v_position coords)
+    # into data coords. With ``v_k = (k - k_min) * extent / (k_max - k_min)``
     # the equation ``a*vx + b*vy + c*vz + d = 0`` becomes
     # ``A*x + B*y + C*z + D = 0`` with the scaling below.
     a, b, c, d = plane
+    extent = _cube_extent(state)
     rng_x = state.x_max - state.x_min
     rng_y = state.y_max - state.y_min
     rng_z = state.z_max - state.z_min
     if rng_x == 0 or rng_y == 0 or rng_z == 0:
         return None
-    A = a * _CUBE_EXTENT / rng_x
-    B = b * _CUBE_EXTENT / rng_y
-    C = c * _CUBE_EXTENT / rng_z
+    A = a * extent / rng_x
+    B = b * extent / rng_y
+    C = c * extent / rng_z
     D = d - A * state.x_min - B * state.y_min - C * state.z_min
     n = np.array([A, B, C])
 

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -1,5 +1,5 @@
 import numpy as np
-from echo import CallbackProperty, SelectionCallbackProperty
+from echo import CallbackProperty, SelectionCallbackProperty, delay_callback
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 
@@ -142,6 +142,26 @@ class Vispy3DVolumeViewerState(VolumeViewerState3D):
     cut_rotation = CallbackProperty(
         0.0, docstring='Azimuthal angle of the plane normal, radians (0..2*pi).')
     cut_depth = CallbackProperty(0.5, docstring='Depth of the cut, 0 (no cut) to 1 (full cut).')
+
+    def flip_cut(self):
+        """Swap the shown and clipped sides of the cutting plane in place.
+
+        Negates the plane normal (``tilt -> pi - tilt``,
+        ``rotation -> rotation + pi``) and mirrors the depth
+        (``depth -> 1 - depth``) so the plane stays put while the kept and
+        removed regions swap. An axis-aligned Simple-mode cut can only ever
+        keep the minus-axis side, so flipping converts the current axis to
+        the equivalent free orientation and switches to Advanced mode.
+        """
+        with delay_callback(self, 'cut_mode', 'cut_tilt', 'cut_rotation', 'cut_depth'):
+            if self.cut_mode == 'Simple':
+                tilt, rotation = _axis_angles(self.cut_axis)
+                self.cut_mode = 'Advanced'
+            else:
+                tilt, rotation = self.cut_tilt, self.cut_rotation
+            self.cut_tilt = float(np.pi - tilt)
+            self.cut_rotation = float((rotation + np.pi) % (2.0 * np.pi))
+            self.cut_depth = 1.0 - self.cut_depth
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -62,7 +62,7 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         self._vispy_widget.add_data_visual(self._cut_outline)
 
         for attr in ('cut_enabled', 'cut_mode', 'cut_axis',
-                     'cut_tilt', 'cut_rotation', 'cut_depth',
+                     'cut_tilt', 'cut_rotation', 'cut_depth', 'cut_flip',
                      'x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max'):
             self.state.add_callback(attr, self._update_cutting_plane)
         self._update_cutting_plane()

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -71,6 +71,26 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
             self.state.add_callback(attr, self._update_cutting_plane)
         self._update_cutting_plane()
 
+        # The volume texture is only re-sliced lazily (on att/resolution
+        # changes), so flipping an axis limit would otherwise leave it stale
+        # until the next camera move. Re-slice immediately when an axis
+        # orientation flips so the cutting plane stays consistent right away.
+        for attr in ('x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max'):
+            self.state.add_callback(attr, self._resample_on_axis_flip)
+
+    def _resample_on_axis_flip(self, *args):
+        bounds = self._vispy_widget._multivol._data_bounds
+        if bounds is None:
+            return
+        # _data_bounds is ordered (z, y, x); compare each axis orientation
+        # (sign of max - min) against the limits the texture was sampled with.
+        (z_lo, z_hi, _), (y_lo, y_hi, _), (x_lo, x_hi, _) = bounds
+        flipped = ((self.state.x_max - self.state.x_min) * (x_hi - x_lo) < 0 or
+                   (self.state.y_max - self.state.y_min) * (y_hi - y_lo) < 0 or
+                   (self.state.z_max - self.state.z_min) * (z_hi - z_lo) < 0)
+        if flipped:
+            self._update_slice_transform()
+
     def _update_cutting_plane(self, *args):
         plane = cutting_plane_from_state(self.state)
         self._vispy_widget._multivol.set_cutting_plane(plane)

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from glue.config import settings
 from glue.viewers.common.viewer import Viewer
-from .viewer_state import Vispy3DVolumeViewerState
+from .viewer_state import Vispy3DVolumeViewerState, cutting_plane_from_state
 
 from ..common.vispy_data_viewer import BaseVispyViewerMixin
 from .layer_artist import VolumeLayerArtist
@@ -49,11 +49,14 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         self.state.add_callback('resolution', self._update_resolution)
         self._update_resolution()
 
-        self.state.add_callback('cutting_plane', self._update_cutting_plane)
+        for attr in ('cut_enabled', 'cut_mode', 'cut_axis',
+                     'cut_tilt', 'cut_rotation', 'cut_depth'):
+            self.state.add_callback(attr, self._update_cutting_plane)
         self._update_cutting_plane()
 
     def _update_cutting_plane(self, *args):
-        self._vispy_widget._multivol.set_cutting_plane(self.state.cutting_plane)
+        plane = cutting_plane_from_state(self.state)
+        self._vispy_widget._multivol.set_cutting_plane(plane)
         self._vispy_widget.canvas.update()
 
     def _update_clip(self, force=False):

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -18,6 +18,12 @@ from ..common import tools as _tools, selection_tools  # noqa
 from . import volume_toolbar  # noqa
 
 
+# Colour of the cutting-plane outline. 50% grey reads as roughly half the
+# contrast of the foreground-coloured bounding box on either a black or a
+# white background.
+GRAY = (0.5, 0.5, 0.5)
+
+
 class VispyVolumeViewerMixin(BaseVispyViewerMixin):
 
     LABEL = "3D Volume Rendering"
@@ -53,10 +59,8 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         self._update_resolution()
 
         # Line visual outlining where the cutting plane meets the box.
-        # 50% grey reads as roughly half the contrast of the foreground-coloured
-        # bounding box on either a black or a white background.
         self._cut_outline = Line(pos=np.zeros((2, 3), dtype=np.float32),
-                                 color=Color((0.5, 0.5, 0.5)),
+                                 color=Color(GRAY),
                                  width=2, connect='strip')
         self._cut_outline.visible = False
         self._vispy_widget.add_data_visual(self._cut_outline)
@@ -76,7 +80,7 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         else:
             # Close the polygon with connect='strip' by repeating the first vertex.
             closed = np.vstack([polygon, polygon[:1]]).astype(np.float32)
-            self._cut_outline.set_data(pos=closed, color=Color((0.5, 0.5, 0.5)))
+            self._cut_outline.set_data(pos=closed, color=Color(GRAY))
             self._cut_outline.visible = True
         self._vispy_widget.canvas.update()
 

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -3,7 +3,10 @@ import numpy as np
 
 from glue.config import settings
 from glue.viewers.common.viewer import Viewer
-from .viewer_state import Vispy3DVolumeViewerState, cutting_plane_from_state
+from vispy.scene.visuals import Line
+from vispy.color import Color
+from .viewer_state import (Vispy3DVolumeViewerState, cutting_plane_from_state,
+                           cutting_plane_polygon)
 
 from ..common.vispy_data_viewer import BaseVispyViewerMixin
 from .layer_artist import VolumeLayerArtist
@@ -49,14 +52,31 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         self.state.add_callback('resolution', self._update_resolution)
         self._update_resolution()
 
+        # Line visual outlining where the cutting plane meets the box.
+        self._cut_outline = Line(pos=np.zeros((2, 3), dtype=np.float32),
+                                 color=Color(settings.FOREGROUND_COLOR),
+                                 width=2, connect='strip')
+        self._cut_outline.visible = False
+        self._vispy_widget.add_data_visual(self._cut_outline)
+
         for attr in ('cut_enabled', 'cut_mode', 'cut_axis',
-                     'cut_tilt', 'cut_rotation', 'cut_depth'):
+                     'cut_tilt', 'cut_rotation', 'cut_depth',
+                     'x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max'):
             self.state.add_callback(attr, self._update_cutting_plane)
         self._update_cutting_plane()
 
     def _update_cutting_plane(self, *args):
         plane = cutting_plane_from_state(self.state)
         self._vispy_widget._multivol.set_cutting_plane(plane)
+        polygon = cutting_plane_polygon(self.state)
+        if polygon is None or len(polygon) < 3:
+            self._cut_outline.visible = False
+        else:
+            # Close the polygon with connect='strip' by repeating the first vertex.
+            closed = np.vstack([polygon, polygon[:1]]).astype(np.float32)
+            self._cut_outline.set_data(pos=closed,
+                                       color=Color(settings.FOREGROUND_COLOR))
+            self._cut_outline.visible = True
         self._vispy_widget.canvas.update()
 
     def _update_clip(self, force=False):

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from glue.config import settings
 from glue.viewers.common.viewer import Viewer
-from glue.viewers.volume3d.viewer_state import VolumeViewerState3D as Vispy3DVolumeViewerState
+from .viewer_state import Vispy3DVolumeViewerState
 
 from ..common.vispy_data_viewer import BaseVispyViewerMixin
 from .layer_artist import VolumeLayerArtist
@@ -48,6 +48,13 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         self.state.add_callback('z_att', self._update_slice_transform)
         self.state.add_callback('resolution', self._update_resolution)
         self._update_resolution()
+
+        self.state.add_callback('cutting_plane', self._update_cutting_plane)
+        self._update_cutting_plane()
+
+    def _update_cutting_plane(self, *args):
+        self._vispy_widget._multivol.set_cutting_plane(self.state.cutting_plane)
+        self._vispy_widget.canvas.update()
 
     def _update_clip(self, force=False):
         if hasattr(self._vispy_widget, '_multivol'):

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -67,6 +67,7 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
 
         for attr in ('cut_enabled', 'cut_mode', 'cut_axis',
                      'cut_tilt', 'cut_rotation', 'cut_depth', 'cut_flip',
+                     'resolution',
                      'x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max'):
             self.state.add_callback(attr, self._update_cutting_plane)
         self._update_cutting_plane()

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -89,7 +89,14 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
                 coords = np.array([[-dx, -dy, -dz], [dx, dy, dz]])
                 coords = (self._vispy_widget._multivol.transform.imap(coords)[:, :3] /
                           self._vispy_widget._multivol.resolution)
-                self._vispy_widget._multivol.set_clip(self.state.clip_data, coords.ravel())
+                # Flipping an axis limit (x_min > x_max) gives the transform a
+                # negative scale, which swaps the two mapped corners so the clip
+                # box comes out inverted (min > max) and the shader clips away
+                # everything. Sort per-axis so the clip box stays well-formed.
+                lo = np.minimum(coords[0], coords[1])
+                hi = np.maximum(coords[0], coords[1])
+                self._vispy_widget._multivol.set_clip(self.state.clip_data,
+                                                      np.concatenate([lo, hi]))
             else:
                 self._vispy_widget._multivol.set_clip(False, [0, 0, 0, 1, 1, 1])
 

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -53,8 +53,10 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         self._update_resolution()
 
         # Line visual outlining where the cutting plane meets the box.
+        # 50% grey reads as roughly half the contrast of the foreground-coloured
+        # bounding box on either a black or a white background.
         self._cut_outline = Line(pos=np.zeros((2, 3), dtype=np.float32),
-                                 color=Color(settings.FOREGROUND_COLOR),
+                                 color=Color((0.5, 0.5, 0.5)),
                                  width=2, connect='strip')
         self._cut_outline.visible = False
         self._vispy_widget.add_data_visual(self._cut_outline)
@@ -74,8 +76,7 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         else:
             # Close the polygon with connect='strip' by repeating the first vertex.
             closed = np.vstack([polygon, polygon[:1]]).astype(np.float32)
-            self._cut_outline.set_data(pos=closed,
-                                       color=Color(settings.FOREGROUND_COLOR))
+            self._cut_outline.set_data(pos=closed, color=Color((0.5, 0.5, 0.5)))
             self._cut_outline.visible = True
         self._vispy_widget.canvas.update()
 

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -101,6 +101,9 @@ class MultiVolumeVisual(VolumeVisual):
         self.shared_program['u_clip_min'] = [0, 0, 0]
         self.shared_program['u_clip_max'] = [1, 1, 1]
 
+        # Set initial cutting plane
+        self.set_cutting_plane(None)
+
         # Set up texture vertices - note that these variables are required by
         # the parent VolumeVisual class.
 
@@ -209,6 +212,16 @@ class MultiVolumeVisual(VolumeVisual):
     def set_multiply(self, label, label_other):
         self.volumes[label]['multiply'] = label_other
         self._update_shader()
+
+    def set_cutting_plane(self, parameters):
+        if parameters is None:
+            # Plane far enough behind the volume that no fragment is
+            # ever excluded; effectively disables the cut.
+            self.shared_program['u_cutting_plane_abc'] = [0, 0, 1]
+            self.shared_program['u_cutting_plane_d'] = -10000.
+        else:
+            self.shared_program['u_cutting_plane_abc'] = list(parameters[:3])
+            self.shared_program['u_cutting_plane_d'] = float(parameters[3])
 
     # The following methods don't require any changes to the shader code, so we
     # don't update the shader after setting the OpenGL variables.
@@ -397,10 +410,7 @@ class MultiVolumeVisual(VolumeVisual):
         if not any(self.enabled):
             return
         else:
-            try:
-                super(MultiVolumeVisual, self).draw()
-            except Exception:
-                pass
+            super(MultiVolumeVisual, self).draw()
 
 
 MultiVolume = create_visual_node(MultiVolumeVisual)

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -215,11 +215,14 @@ class MultiVolumeVisual(VolumeVisual):
 
     def set_cutting_plane(self, parameters):
         if parameters is None:
-            # Plane far enough behind the volume that no fragment is
-            # ever excluded; effectively disables the cut.
+            # Flag the shader to skip the cutting-plane code path entirely.
+            # The abc/d uniforms still need *some* value bound or vispy
+            # will complain at draw time, but it doesn't matter what.
+            self.shared_program['u_cutting_plane_enabled'] = 0
             self.shared_program['u_cutting_plane_abc'] = [0, 0, 1]
-            self.shared_program['u_cutting_plane_d'] = -10000.
+            self.shared_program['u_cutting_plane_d'] = 0.
         else:
+            self.shared_program['u_cutting_plane_enabled'] = 1
             self.shared_program['u_cutting_plane_abc'] = list(parameters[:3])
             self.shared_program['u_cutting_plane_d'] = float(parameters[3])
 


### PR DESCRIPTION
This implements a simple cutting plane which can optionally be arbitrarily oriented. A follow-up in a separate PR would be to investigate showing an actual image/colormap on the plane (could be a toggle on/off thing)

Main TODOs:

* [x] Have a toggle in the shaders for turning cutting plane on/off
* [x] Implement UI options to set the cutting plane - could have simple mode where one just cuts in x, y, or z, and then have an advanced mode where all the coefficients can be edited.
* [x] Added visual tests (either here or in glue-jupyter)