### PR TITLE
Use texture strips for colormaps

### DIFF
--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -54,13 +54,14 @@ class CustomColormap(BaseColormap):
         self.uuid = uuid4().hex
         self.texture_name = f"texture2D_LUT_{self.uuid}"
         self.glsl_map = f"""
-        uniform sample2D {self.texture_name};
+        uniform sampler2D {self.texture_name};
         vec4 colormap(float t) {{
             return texture2D({self.texture_name}, vec2(0.0, clamp(t, 0.0, 1.0)));
         }}
         """
-        super().__init__(colors, bad_color=bad_color,
-                         high_color=high_color, low_color=low_color)
+
+    def texture_lut(self):
+        return self.texture_map_data
 
 
 def get_translucent_cmap(r, g, b, stretch):

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,6 +1,8 @@
+import numpy as np
 from glue.config import AsinhStretch, LinearStretch, LogStretch, SqrtStretch, DictRegistry
 from matplotlib.colors import ListedColormap
-from vispy.color import BaseColormap, Colormap
+from vispy.color import BaseColormap, ColorArray
+from vispy.color.colormap import LUT_len
 from uuid import uuid4
 
 
@@ -24,14 +26,39 @@ def glsl_for_stretch(stretch, parameter="t"):
     return template.format(stretch=stretch, parameter=parameter)
 
 
-class CustomColormap(Colormap):
+# This is based on `vispy.color.colormap.Colormap`
+# In a similar vein to how we needed to create our own MultiVolumeVisual class,
+# the primary issue with the VisPy Colormap class is that the colormap shader
+# creates a particular name for the sampler uniform, but we need a separate
+# sampler for each layer
+class CustomColormap(BaseColormap):
 
-    def __init__(self, colors, controls=None, interpolation="linear"):
-        super().__init__(colors, controls=controls, interpolation=interpolation)
+    def __init__(self, colors, controls=None, *,
+                 bad_color=None, low_color=None, high_color=None):
+
+        ncontrols = len(colors)
+        if controls is None:
+            controls = np.linspace(0.0, 1.0, ncontrols)
+        assert len(controls) == ncontrols
+        self._controls = np.array(controls, dtype=np.float32)
+
+        c_rgba = ColorArray(colors).rgba
+        self.texture_map_data = np.zeros((LUT_len, 1, 4), dtype=np.float32)
+        self.texture_map_data[:, 0, 0] = np.interp(x, controls, c_rgba[:, 0])
+        self.texture_map_data[:, 0, 1] = np.interp(x, controls, c_rgba[:, 1])
+        self.texture_map_data[:, 0, 2] = np.interp(x, controls, c_rgba[:, 2])
+        self.texture_map_data[:, 0, 3] = np.interp(x, controls, c_rgba[:, 3])
 
         self.uuid = uuid4().hex
         self.texture_name = f"texture2D_LUT_{self.uuid}"
-        self.glsl_map = self.glsl_map.replace("texture2D_LUT", self.texture_name)
+        self.glsl_map = f"""
+        uniform sample2D {self.texture_name};
+        vec4 colormap(float t) {{
+            return texture2D({self.texture_name}, vec2(0.0, clamp(t, 0.0, 1.0)));
+        }}
+        """
+        super().__init__(colors, bad_color=bad_color,
+                         high_color=high_color, low_color=low_color)
 
 
 def get_translucent_cmap(r, g, b, stretch):
@@ -60,4 +87,4 @@ def get_mpl_cmap(cmap, stretch):
         ts = stretch([index / (n_colors - 1) for index in range(n_colors)])
         colors = [[*cmap(t)[:3], t] for t in ts]
 
-    return CustomColormap(colors=colors, controls=ts, interpolation="linear")
+    return CustomColormap(colors=colors, controls=ts)

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,6 +1,7 @@
 from glue.config import AsinhStretch, LinearStretch, LogStretch, SqrtStretch, DictRegistry
 from matplotlib.colors import ListedColormap
-from vispy.color import BaseColormap
+from vispy.color import BaseColormap, Colormap
+from numpy import linspace
 
 
 class GLSLStretchRegistry(DictRegistry):
@@ -22,16 +23,11 @@ def create_cmap_template(n, stretch_glsl):
     ts = tuple((i + 1) / n for i in range(n-1))
     lines = [
         "vec4 translucent_colormap(float t) {",
-        f"    float s = {stretch_glsl};"
+        "    return texture2D(s_texture, vec2(t, 0.0));"
+        "}",
     ]
-    for i, t in enumerate(ts):
-        lines.append(f"    if (s <= {t})")
-        lines.append(f"        {{ return $color_{i}; }}")
-    lines.append(f"    return $color_{n-1};")
-    lines.append("}")
 
     return "\n".join(lines)
-
 
 def glsl_for_stretch(stretch, parameter="t"):
     template = stretch_glsl.members.get(type(stretch), "{param}")
@@ -75,16 +71,20 @@ def get_mpl_cmap(cmap, stretch):
         step = max(1, len(all_colors) // n_colors)
         colors = list(all_colors[::step])[:n_colors]
         n_colors = len(colors)
-        ts = stretch([index / n_colors for index in range(n_colors)])
+        ts = stretch([index / (n_colors - 1) for index in range(n_colors)])
         colors = [[*color, t] for t, color in zip(ts, colors)]
     else:
-        ts = stretch([index / n_colors for index in range(n_colors)])
+        ts = stretch([index / (n_colors - 1) for index in range(n_colors)])
         colors = [[*cmap(t)[:3], t] for t in ts]
 
     stretch_glsl = glsl_for_stretch(stretch)
     template = create_cmap_template(n_colors, stretch_glsl)
 
-    class MatplotlibCmap(BaseColormap):
-        glsl_map = template
+    class MatplotlibCmap(Colormap):
 
-    return MatplotlibCmap(colors=colors)
+        def __init__(self, colors, controls):
+            print(controls)
+            super().__init__(colors, controls=controls, interpolation="linear")
+
+
+    return MatplotlibCmap(colors=colors, controls=ts)

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -44,6 +44,8 @@ class CustomColormap(BaseColormap):
 
         c_rgba = ColorArray(colors).rgba
         self.texture_map_data = np.zeros((LUT_len, 1, 4), dtype=np.float32)
+        texture_len = self.texture_map_data.shape[0]
+        x = np.linspace(0.0, 1.0, texture_len)
         self.texture_map_data[:, 0, 0] = np.interp(x, controls, c_rgba[:, 0])
         self.texture_map_data[:, 0, 1] = np.interp(x, controls, c_rgba[:, 1])
         self.texture_map_data[:, 0, 2] = np.interp(x, controls, c_rgba[:, 2])

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -60,6 +60,9 @@ class CustomColormap(BaseColormap):
         }}
         """
 
+        super().__init__(colors, bad_color=bad_color,
+                         high_color=high_color, low_color=low_color)
+
     def texture_lut(self):
         return self.texture_map_data
 

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,7 +1,7 @@
 from glue.config import AsinhStretch, LinearStretch, LogStretch, SqrtStretch, DictRegistry
 from matplotlib.colors import ListedColormap
 from vispy.color import BaseColormap, Colormap
-from numpy import linspace
+from uuid import uuid4
 
 
 class GLSLStretchRegistry(DictRegistry):
@@ -19,19 +19,19 @@ stretch_glsl.add(AsinhStretch,
 stretch_glsl.add(LinearStretch, "{parameter}")
 
 
-def create_cmap_template(n, stretch_glsl):
-    ts = tuple((i + 1) / n for i in range(n-1))
-    lines = [
-        "vec4 translucent_colormap(float t) {",
-        "    return texture2D(s_texture, vec2(t, 0.0));"
-        "}",
-    ]
-
-    return "\n".join(lines)
-
 def glsl_for_stretch(stretch, parameter="t"):
     template = stretch_glsl.members.get(type(stretch), "{param}")
     return template.format(stretch=stretch, parameter=parameter)
+
+
+class CustomColormap(Colormap):
+
+    def __init__(self, colors, controls=None, interpolation="linear"):
+        super().__init__(colors, controls=controls, interpolation=interpolation)
+
+        self.uuid = uuid4().hex
+        self.texture_name = f"texture2D_LUT_{self.uuid}"
+        self.glsl_map = self.glsl_map.replace("texture2D_LUT", self.texture_name)
 
 
 def get_translucent_cmap(r, g, b, stretch):
@@ -50,41 +50,14 @@ def get_translucent_cmap(r, g, b, stretch):
 
 def get_mpl_cmap(cmap, stretch):
 
-    # Mesa llvmpipe (Linux/CI software OpenGL) miscompiles the long
-    # chained-if function emitted by ``create_cmap_template`` past some
-    # length. Uniform-data probes suggested the chain is fine up to ~100
-    # ifs, but real-data tests show n=100 produces dark-speckle artifacts
-    # on a small fraction of t values (~1000 broken pixels in an L1448
-    # cube render at n=100, vs 0 at n=80 and n=64). 64 is a comfortable
-    # margin that's been visually verified to match Apple's GL output on
-    # real data. Apple's GL handles long chains fine; this cap is purely
-    # to keep CI/headless renders matching real-GPU output.
-    #
-    # Most matplotlib cmaps (including plasma/viridis/inferno) are
-    # ``ListedColormap`` with 256 entries -- without this cap the bug
-    # triggers on every standard mpl cmap.
-    n_colors = 64
-
     if isinstance(cmap, ListedColormap):
-        all_colors = cmap.colors
-        # Subsample if the cmap has more entries than n_colors
-        step = max(1, len(all_colors) // n_colors)
-        colors = list(all_colors[::step])[:n_colors]
+        colors = cmap.colors
         n_colors = len(colors)
         ts = stretch([index / (n_colors - 1) for index in range(n_colors)])
         colors = [[*color, t] for t, color in zip(ts, colors)]
     else:
+        n_colors = 256
         ts = stretch([index / (n_colors - 1) for index in range(n_colors)])
         colors = [[*cmap(t)[:3], t] for t in ts]
 
-    stretch_glsl = glsl_for_stretch(stretch)
-    template = create_cmap_template(n_colors, stretch_glsl)
-
-    class MatplotlibCmap(Colormap):
-
-        def __init__(self, colors, controls):
-            print(controls)
-            super().__init__(colors, controls=controls, interpolation="linear")
-
-
-    return MatplotlibCmap(colors=colors, controls=ts)
+    return CustomColormap(colors=colors, controls=ts, interpolation="linear")

--- a/glue_vispy_viewers/volume/tests/test_colors.py
+++ b/glue_vispy_viewers/volume/tests/test_colors.py
@@ -1,39 +1,13 @@
 from re import sub
 
+from vispy.color.colormap import LUT_len
 from glue.config import LinearStretch, colormaps
-from glue_vispy_viewers.volume.colors import create_cmap_template, get_mpl_cmap, \
-                                             get_translucent_cmap, glsl_for_stretch
+from glue_vispy_viewers.volume.colors import CustomColormap, get_mpl_cmap, \
+                                             get_translucent_cmap
 
 
 def clean_template(template):
     return sub("( |\n)", "", template)
-
-
-def test_create_cmap_template():
-
-    n_colors = 4
-    stretch = LinearStretch()
-    stretch_glsl = glsl_for_stretch(stretch)
-    template = clean_template(create_cmap_template(n=n_colors, stretch_glsl=stretch_glsl))
-
-    # vispy adds some extra code to the GLSL map for mapping bad values (e.g. NaN)
-    # to a default color, so we need to account for that.
-    # If this becomes more complicated we could use a regex, but with all of the parentheses
-    # and brackets this feels simpler
-    template_start = clean_template("vec4 translucent_colormap(float t) {")
-    template_end = clean_template("""
-        float s = t;
-        if (s <= 0.25)
-            { return $color_0; }
-        if (s <= 0.5)
-            { return $color_1; }
-        if (s <= 0.75)
-            { return $color_2; }
-        return $color_3;
-    }
-    """)
-    assert template.startswith(template_start)
-    assert template.endswith(template_end)
 
 
 def test_translucent_cmap():
@@ -51,38 +25,19 @@ def test_translucent_cmap():
     assert template.endswith(template_end)
 
 
-# Both Linear and Listed paths in get_mpl_cmap are now capped to 64 entries
-# to work around a Mesa llvmpipe miscompilation of the long chained-if
-# function emitted by create_cmap_template. See the comment in colors.py.
-EXPECTED_N_COLORS = 64
-
-
 def test_linear_cmap():
 
     colormap = colormaps['Red-Blue']
     stretch = LinearStretch()
-    stretch_glsl = glsl_for_stretch(stretch)
     cmap = get_mpl_cmap(colormap, stretch)
-    assert len(cmap.colors) == EXPECTED_N_COLORS
-
-    template = create_cmap_template(EXPECTED_N_COLORS, stretch_glsl)
-    template_start, template_end = [clean_template(t) for t in template.split("\n", maxsplit=1)]
-    template = clean_template(template)
-    assert template.startswith(template_start)
-    assert template.endswith(template_end)
+    assert isinstance(cmap, CustomColormap)
+    assert cmap.texture_map_data.shape == (LUT_len, 1, 4)
 
 
 def test_listed_cmap():
 
     colormap = colormaps['Viridis']
     stretch = LinearStretch()
-    stretch_glsl = glsl_for_stretch(stretch)
     cmap = get_mpl_cmap(colormap, stretch)
-    # Cap kicks in: source has 256 entries, we downsample to 64.
-    assert len(cmap.colors) == EXPECTED_N_COLORS
-
-    template = create_cmap_template(EXPECTED_N_COLORS, stretch_glsl)
-    template_start, template_end = [clean_template(t) for t in template.split("\n", maxsplit=1)]
-    template = clean_template(template)
-    assert template.startswith(template_start)
-    assert template.endswith(template_end)
+    assert isinstance(cmap, CustomColormap)
+    assert cmap.texture_map_data.shape == (LUT_len, 1, 4)

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -71,7 +71,7 @@ class MultiVolumeVisual(VolumeVisual):
         Absolute maximum number of volumes that can be shown.
     """
 
-    def __init__(self, n_volume_max=16, emulate_texture=False, bgcolor='white', resolution=256):
+    def __init__(self, n_volume_max=8, emulate_texture=False, bgcolor='white', resolution=256):
 
         # Choose texture class
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D
@@ -262,6 +262,8 @@ class MultiVolumeVisual(VolumeVisual):
         self.volumes[label]['cmap'] = cmap
         index = self.volumes[label]['index']
         self.shared_program.frag['cmap{0:d}'.format(index)] = Function(cmap.glsl_map)
+        if hasattr(cmap, "texture_name"):
+            self.shared_program[cmap.texture_name] = cmap.texture_lut()
 
     def set_clim(self, label, clim):
         # Avoid setting the same limits again

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -71,7 +71,7 @@ class MultiVolumeVisual(VolumeVisual):
         Absolute maximum number of volumes that can be shown.
     """
 
-    def __init__(self, n_volume_max=8, emulate_texture=False, bgcolor='white', resolution=256):
+    def __init__(self, n_volume_max=16, emulate_texture=False, bgcolor='white', resolution=256):
 
         # Choose texture class
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     echo>=0.15.0
     scipy
     matplotlib
-    vispy>=0.14.0
+    vispy>=0.15.0
     glfw
     imageio
 python_requires = >=3.10


### PR DESCRIPTION
This PR modifies our implementation of colormaps to use a texture strip rather than the long repeated if-else GLSL that we currently generate.

The functionality here is largely lifted from Vispy's own colormap class. The subclassing is really only necessary for the same reason that we created the multi-volume visual - Vispy expects to only have one volume and thus need only one colormap, so it gives all colormap instance textures the same uniform name. The class in this PR provides a unique texture name for each colormap so that we can bind multiple colormap uniforms to the shared program.

@astrofrog As I mentioned on Slack, my main concern here is the max number of textures for a given shader.