### PR TITLE
Allow changing background color of cutting plane image

### DIFF
--- a/glue_vispy_viewers/volume/jupyter/viewer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/viewer_state_widget.vue
@@ -69,6 +69,22 @@
                 <v-slider v-model="cut_plane_image_opacity" :min="0" :max="1" :step="0.001" hide-details thumb-label="hidden" />
             </div>
             <div>
+                <v-subheader class="pl-0 slider-label">plane background</v-subheader>
+                <v-menu ref="menu">
+                    <template v-slot:activator="{ on, props }">
+                        <span class="glue-color-menu"
+                              @click.stop="on.click"
+                        >&nbsp;</span>
+                    </template>
+                    <div @click.stop="" style="text-align: end; background-color: white">
+                        <v-btn icon @click="$refs.menu.save()">
+                            <v-icon>mdi-close</v-icon>
+                        </v-btn>
+                        <v-color-picker v-model="cut_plane_image_bgcolor" echo-type="text" ></v-color-picker>
+                    </div>
+                </v-menu>
+            </div>
+            <div>
                 <v-btn small block class="mt-2" @click="flip_cut">Flip shown/clipped side</v-btn>
             </div>
         </template>

--- a/glue_vispy_viewers/volume/qt/cutting_plane_widget.ui
+++ b/glue_vispy_viewers/volume/qt/cutting_plane_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>276</width>
-    <height>220</height>
+    <height>247</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -57,10 +57,44 @@
       <property name="verticalSpacing">
        <number>4</number>
       </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_mode">
+      <item row="2" column="1">
+       <widget class="QSlider" name="value_cut_tilt">
+        <property name="maximum">
+         <number>180</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="QPushButton" name="button_flip_cut">
         <property name="text">
-         <string>Mode:</string>
+         <string>Flip shown/clipped side</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_depth">
+        <property name="text">
+         <string>Depth:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_image">
+        <property name="text">
+         <string>Image opacity:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSlider" name="value_cut_depth">
+        <property name="maximum">
+         <number>1000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
@@ -74,10 +108,51 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_mode">
+        <property name="text">
+         <string>Mode:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_tilt">
+        <property name="text">
+         <string>Tilt:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QSlider" name="value_cut_plane_image_opacity">
+        <property name="maximum">
+         <number>1000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSlider" name="value_cut_rotation">
+        <property name="maximum">
+         <number>360</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_axis">
         <property name="text">
          <string>Axis:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_rotation">
+        <property name="text">
+         <string>Rotation:</string>
         </property>
        </widget>
       </item>
@@ -133,78 +208,17 @@
         </layout>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_tilt">
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_color">
         <property name="text">
-         <string>Tilt:</string>
+         <string>Image background:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QSlider" name="value_cut_tilt">
-        <property name="maximum">
-         <number>180</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_rotation">
+      <item row="6" column="1">
+       <widget class="QColorBox" name="color_cut_plane_image_bgcolor">
         <property name="text">
-         <string>Rotation:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QSlider" name="value_cut_rotation">
-        <property name="maximum">
-         <number>360</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_depth">
-        <property name="text">
-         <string>Depth:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QSlider" name="value_cut_depth">
-        <property name="maximum">
-         <number>1000</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_image">
-        <property name="text">
-         <string>Image opacity:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QSlider" name="value_cut_plane_image_opacity">
-        <property name="maximum">
-         <number>1000</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QPushButton" name="button_flip_cut">
-        <property name="text">
-         <string>Flip shown/clipped side</string>
+         <string/>
         </property>
        </widget>
       </item>
@@ -226,6 +240,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QColorBox</class>
+   <extends>QLabel</extends>
+   <header>glue_qt.utils.colors</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -94,6 +94,8 @@ uniform float u_cutting_plane_d;
 // the visible face of the remaining volume rather than hiding behind it.
 uniform float u_cut_plane_image_opacity;
 
+uniform vec4 u_cut_plane_image_bgcolor;
+
 // uniforms for lighting. Hard coded until we figure out how to do lights
 const vec4 u_ambient = vec4(0.2, 0.4, 0.2, 1.0);
 const vec4 u_diffuse = vec4(0.8, 0.2, 0.2, 1.0);
@@ -266,7 +268,7 @@ void main() {{
     // over the MIP result at the user-controlled opacity.
     if (u_cut_plane_image_opacity > 0.0 && plane_image_visible == 1) {{
         vec3 plane_loc = (v_position + view_ray * plane_t) / u_shape;
-        vec4 plane_total_color = vec4(0., 0., 0., 0.);
+        vec4 plane_total_color = u_cut_plane_image_bgcolor;
         vec4 plane_color = vec4(0., 0., 0., 0.);
         float plane_count = 0.;
         float plane_val;
@@ -391,7 +393,7 @@ def get_frag_shader(volumes, clipped=False, n_volume_max=5):
         # opacity) is non-zero. Count every in-bounds sample and average the
         # colourmap colours directly so values at or below v_min still render
         # (as dark pixels via the premultiply) instead of leaving holes.
-        plane_sample += "plane_total_color += plane_color;\n"
+        plane_sample += "plane_total_color.rgb = mix(plane_total_color.rgb, plane_color.rgb, plane_color.a);\n"
         plane_sample += "plane_count += 1.0;\n\n"
         if clipped:
             plane_sample += "}\n\n"

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -393,7 +393,8 @@ def get_frag_shader(volumes, clipped=False, n_volume_max=5):
         # opacity) is non-zero. Count every in-bounds sample and average the
         # colourmap colours directly so values at or below v_min still render
         # (as dark pixels via the premultiply) instead of leaving holes.
-        plane_sample += "plane_total_color.rgb = mix(plane_total_color.rgb, plane_color.rgb, plane_color.a);\n"
+        plane_sample += ("plane_total_color.rgb = "
+                         "mix(plane_total_color.rgb, plane_color.rgb, plane_color.a);\n")
         plane_sample += "plane_count += 1.0;\n\n"
         if clipped:
             plane_sample += "}\n\n"

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -167,6 +167,9 @@ class Vispy3DVolumeViewerState(VolumeViewerState3D):
         False, docstring='Whether to show the opposite side of the cutting plane.')
     cut_plane_image_opacity = CallbackProperty(
         0.0, docstring='Opacity of the slice image rendered on the cutting plane (0 = off).')
+    cut_plane_image_bgcolor = CallbackProperty(
+        "#000000", docstring='Base color of the cutting plane')
+
 
     def flip_cut(self):
         """Swap which side of the cutting plane is shown versus clipped.

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -170,7 +170,6 @@ class Vispy3DVolumeViewerState(VolumeViewerState3D):
     cut_plane_image_bgcolor = CallbackProperty(
         "#000000", docstring='Base color of the cutting plane')
 
-
     def flip_cut(self):
         """Swap which side of the cutting plane is shown versus clipped.
 

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -71,6 +71,7 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
                      'x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max'):
             self.state.add_callback(attr, self._update_cutting_plane)
         self.state.add_callback('cut_plane_image_opacity', self._update_cut_plane_image_opacity)
+        self.state.add_callback('cut_plane_image_bgcolor', self._update_cut_plane_image_bgcolor)
         self._update_cutting_plane()
         self._update_cut_plane_image_opacity()
 
@@ -85,6 +86,10 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         # orientation flips so the cutting plane stays consistent right away.
         for attr in ('x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max'):
             self.state.add_callback(attr, self._resample_on_axis_flip)
+
+    def _update_cut_plane_image_bgcolor(self, *args):
+        self._vispy_widget._multivol.set_cut_plane_image_bgcolor(self.state.cut_plane_image_bgcolor)
+        self._vispy_widget.canvas.update()
 
     def _resample_on_axis_flip(self, *args):
         bounds = self._vispy_widget._multivol._data_bounds

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -232,8 +232,6 @@ class MultiVolumeVisual(VolumeVisual):
         self.shared_program['u_cut_plane_image_opacity'] = float(opacity)
 
     def set_cut_plane_image_bgcolor(self, color):
-        print("Setting cut plane bgcolor")
-        print(Color(color).rgba)
         self.shared_program['u_cut_plane_image_bgcolor'] = Color(color).rgba
 
     # The following methods don't require any changes to the shader code, so we

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -104,6 +104,7 @@ class MultiVolumeVisual(VolumeVisual):
         # Set initial cutting plane and slice-image overlay
         self.set_cutting_plane(None)
         self.set_cut_plane_image_opacity(0.0)
+        self.set_cut_plane_image_bgcolor(Color("black").rgba)
 
         # Set up texture vertices - note that these variables are required by
         # the parent VolumeVisual class.
@@ -229,6 +230,11 @@ class MultiVolumeVisual(VolumeVisual):
 
     def set_cut_plane_image_opacity(self, opacity):
         self.shared_program['u_cut_plane_image_opacity'] = float(opacity)
+
+    def set_cut_plane_image_bgcolor(self, color):
+        print("Setting cut plane bgcolor")
+        print(Color(color).rgba)
+        self.shared_program['u_cut_plane_image_bgcolor'] = Color(color).rgba
 
     # The following methods don't require any changes to the shader code, so we
     # don't update the shader after setting the OpenGL variables.


### PR DESCRIPTION
This is a request that Alyssa asked for while we were looking at the cutting plane functionality. The idea is to allow the image plane to contrast with the background color - for example, to let the plane be white rather than black if the viewers are set to have black backgrounds. Since users can set the viewer background color to whatever they want, this PR allows them to do the same with the cutting plane image background.

@astrofrog I think this is the right approach but let me know if you see any issues