### PR TITLE
Allow setting separate color/colormap on cutting plane

### DIFF
--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
@@ -25,3 +25,4 @@ class Volume3DLayerStateWidget(v.VuetifyTemplate):
 
         extras = {"cmap": cmap_extras(self), "cut_plane_cmap": cmap_extras(self)}
         autoconnect_callbacks_to_vue(layer_state, self, extras=extras, skip={"subset"})
+        autoconnect_callbacks_to_vue(layer_state.viewer_state, self, only={"cut_enabled"})

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
@@ -23,5 +23,5 @@ class Volume3DLayerStateWidget(v.VuetifyTemplate):
 
         self.subset = isinstance(layer_state.layer, Subset)
 
-        extras = {"cmap": cmap_extras(self)}
+        extras = {"cmap": cmap_extras(self), "cut_plane_cmap": cmap_extras(self)}
         autoconnect_callbacks_to_vue(layer_state, self, extras=extras, skip={"subset"})

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
@@ -3,14 +3,12 @@
         <div>
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details class="margin-bottom: 16px" />
         </div>
+        <div v-if="!subset">
+            <v-select label="color mode" :items="color_mode_items" v-model="color_mode_selected" hide-details />
+        </div>
         <template v-if="(color_mode_items[color_mode_selected] || {}).text === 'Linear'">
           <div>
               <v-select label="colormap" :items="cmap_items" v-model="cmap" hide-details />
-          </div>
-        </template>
-        <template v-else>
-          <div v-if="!subset">
-              <v-select label="color" :items="color_mode_items" v-model="color_mode_selected" hide-details />
           </div>
         </template>
         <div>
@@ -26,6 +24,33 @@
         <div>
             <glue-float-field label="max" :value.sync="v_max" echo-type="float" />
         </div>
+        <template v-if="true">
+          <v-subheader>Cutting plane</v-subheader>
+          <div v-if="!subset">
+              <v-select label="color mode" :items="cut_plane_color_mode_items" v-model="cut_plane_color_mode_selected" hide-details />
+          </div>
+          <template v-if="(cut_plane_color_mode_items[cut_plane_color_mode_selected] || {}).text === 'Linear'">
+            <div>
+                <v-select label="colormap" :items="cmap_items" v-model="cut_plane_cmap" hide-details />
+            </div>
+          </template>
+          <template v-else>
+            <v-subheader class="pl-0 slider-label">color</v-subheader>
+            <v-menu ref="menu">
+                <template v-slot:activator="{ on, props }">
+                    <span class="glue-color-menu"
+                          @click.stop="on.click"
+                    >&nbsp;</span>
+                </template>
+                <div @click.stop="" style="text-align: end; background-color: white">
+                    <v-btn icon @click="$refs.menu.save()">
+                        <v-icon>mdi-close</v-icon>
+                    </v-btn>
+                    <v-color-picker v-model="cut_plane_color" echo-type="text" ></v-color-picker>
+                </div>
+            </v-menu>
+          </template>
+        </template>
     </div>
 </template>
 

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
@@ -24,7 +24,7 @@
         <div>
             <glue-float-field label="max" :value.sync="v_max" echo-type="float" />
         </div>
-        <template v-if="true">
+        <template v-if="cut_enabled">
           <v-subheader>Cutting plane</v-subheader>
           <div v-if="!subset">
               <v-select label="color mode" :items="cut_plane_color_mode_items" v-model="cut_plane_color_mode_selected" hide-details />

--- a/glue_vispy_viewers/volume/jupyter/viewer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/viewer_state_widget.vue
@@ -69,6 +69,22 @@
                 <v-slider v-model="cut_plane_image_opacity" :min="0" :max="1" :step="0.001" hide-details thumb-label="hidden" />
             </div>
             <div>
+                <v-subheader class="pl-0 slider-label">plane background</v-subheader>
+                <v-menu ref="menu">
+                    <template v-slot:activator="{ on, props }">
+                        <span class="glue-color-menu"
+                              @click.stop="on.click"
+                        >&nbsp;</span>
+                    </template>
+                    <div @click.stop="" style="text-align: end; background-color: white">
+                        <v-btn icon @click="$refs.menu.save()">
+                            <v-icon>mdi-close</v-icon>
+                        </v-btn>
+                        <v-color-picker v-model="cut_plane_image_bgcolor" echo-type="text" ></v-color-picker>
+                    </div>
+                </v-menu>
+            </div>
+            <div>
                 <v-btn small block class="mt-2" @click="flip_cut">Flip shown/clipped side</v-btn>
             </div>
         </template>

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -100,7 +100,7 @@ class VolumeLayerArtist(VispyLayerArtist):
     def _update_plane_cmap(self):
         if self.state.cut_plane_color_mode == "Fixed":
             color = self.state.cut_plane_color or self.state.color
-            cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color),
+            cmap = get_translucent_cmap(*ColorConverter().to_rgb(color),
                                         self.state.stretch_object)
         else:
             cmap = get_mpl_cmap(self.state.cut_plane_cmap or self.state.cmap, self.state.stretch_object)

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -5,13 +5,14 @@ from matplotlib.colors import ColorConverter
 from glue.core.data import Subset, Data
 from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
 from glue.viewers.volume3d.data_proxy import DataProxy
-from glue.viewers.volume3d.layer_state import VolumeLayerState3D
 
 from .colors import get_mpl_cmap, get_translucent_cmap
+from .layer_state import VispyVolumeLayerState
 from ..common.layer_artist import VispyLayerArtist
 
 
 COLOR_PROPERTIES = set(['cmap', 'color', 'color_mode', 'stretch', 'stretch_parameters'])
+CUT_PLANE_PROPERTIES = set(['cut_plane_color', 'cut_plane_color_mode', 'cut_plane_cmap', 'stretch', 'stretch_parameters'])
 
 
 class VolumeLayerArtist(VispyLayerArtist):
@@ -23,7 +24,7 @@ class VolumeLayerArtist(VispyLayerArtist):
     each data viewer.
     """
 
-    _layer_state_cls = VolumeLayerState3D
+    _layer_state_cls = VispyVolumeLayerState
 
     def __init__(self, vispy_viewer=None, layer=None, layer_state=None):
 
@@ -98,10 +99,11 @@ class VolumeLayerArtist(VispyLayerArtist):
 
     def _update_plane_cmap(self):
         if self.state.cut_plane_color_mode == "Fixed":
-            cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.cut_plane_color),
+            color = self.state.cut_plane_color or self.state.color
+            cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color),
                                         self.state.stretch_object)
         else:
-            cmap = get_mpl_cmap(self.state.cut_plane_cmap, self.state.stretch_object)
+            cmap = get_mpl_cmap(self.state.cut_plane_cmap or self.state.cmap, self.state.stretch_object)
 
         self._multivol.set_cut_plane_cmap(self.id, cmap)
         self.redraw()
@@ -154,6 +156,9 @@ class VolumeLayerArtist(VispyLayerArtist):
 
         if force or len(changed & COLOR_PROPERTIES) > 0:
             self._update_cmap()
+
+        if force or len(changed & CUT_PLANE_PROPERTIES) > 0:
+            self._update_plane_cmap()
 
         if force or 'v_min' in changed or 'v_max' in changed:
             self._update_limits()

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -12,7 +12,8 @@ from ..common.layer_artist import VispyLayerArtist
 
 
 COLOR_PROPERTIES = set(['cmap', 'color', 'color_mode', 'stretch', 'stretch_parameters'])
-CUT_PLANE_PROPERTIES = set(['cut_plane_color', 'cut_plane_color_mode', 'cut_plane_cmap', 'stretch', 'stretch_parameters'])
+CUT_PLANE_PROPERTIES = set(['cut_plane_color', 'cut_plane_color_mode',
+                            'cut_plane_cmap', 'stretch', 'stretch_parameters'])
 
 
 class VolumeLayerArtist(VispyLayerArtist):
@@ -103,7 +104,8 @@ class VolumeLayerArtist(VispyLayerArtist):
             cmap = get_translucent_cmap(*ColorConverter().to_rgb(color),
                                         self.state.stretch_object)
         else:
-            cmap = get_mpl_cmap(self.state.cut_plane_cmap or self.state.cmap, self.state.stretch_object)
+            cmap = get_mpl_cmap(self.state.cut_plane_cmap or self.state.cmap,
+                                self.state.stretch_object)
 
         self._multivol.set_cut_plane_cmap(self.id, cmap)
         self.redraw()

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -96,6 +96,16 @@ class VolumeLayerArtist(VispyLayerArtist):
         self._multivol.set_cmap(self.id, cmap)
         self.redraw()
 
+    def _update_plane_cmap(self):
+        if self.state.cut_plane_color_mode == "Fixed":
+            cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.cut_plane_color),
+                                        self.state.stretch_object)
+        else:
+            cmap = get_mpl_cmap(self.state.cut_plane_cmap, self.state.stretch_object)
+
+        self._multivol.set_cut_plane_cmap(self.id, cmap)
+        self.redraw()
+
     def _update_limits(self):
         if isinstance(self.layer, Subset):
             self._multivol.set_clim(self.id, None)

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -7,7 +7,7 @@ from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
 from glue.viewers.volume3d.data_proxy import DataProxy
 
 from .colors import get_mpl_cmap, get_translucent_cmap
-from .layer_state import VispyVolumeLayerState
+from .layer_state import VolumeLayerState
 from ..common.layer_artist import VispyLayerArtist
 
 
@@ -24,7 +24,7 @@ class VolumeLayerArtist(VispyLayerArtist):
     each data viewer.
     """
 
-    _layer_state_cls = VispyVolumeLayerState
+    _layer_state_cls = VolumeLayerState
 
     def __init__(self, vispy_viewer=None, layer=None, layer_state=None):
 

--- a/glue_vispy_viewers/volume/layer_state.py
+++ b/glue_vispy_viewers/volume/layer_state.py
@@ -1,12 +1,30 @@
-import warnings
+from echo import CallbackProperty, SelectionCallbackProperty
 
 from glue.viewers.volume3d.layer_state import VolumeLayerState3D as VolumeLayerState
 
-__all__ = ['VolumeLayerState']
+__all__ = ['VispyVolumeLayerState']
 
-warnings.warn(
-    "Importing VolumeLayerState from glue_vispy_viewers.volume.layer_state is deprecated. "
-    "Please import VolumeLayerState from glue.viewers.volume3d.layer_state instead.",
-    DeprecationWarning,
-    stacklevel=2
-)
+
+class VispyVolumeLayerState(VolumeLayerState):
+    """Volume layer state with vispy-only extensions.
+
+    Subclasses ``glue.viewers.volume3d.layer_state.VolumeLayerState``
+    and adds attributes that only make sense for the vispy-based volume
+    renderer, so they aren't visible from non-vispy frontends (notably
+    ipyvolume) which would otherwise ignore them. If/when those become
+    cross-frontend concepts they can be lifted into glue-core.
+    """
+
+    cut_plane_color_mode = SelectionCallbackProperty(
+        0, choices=['Fixed', 'Linear']
+    )
+    cut_plane_color = CallbackProperty()
+    cut_plane_cmap = CallbackProperty()
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # SelectionCallbackProperty stores choices per-instance via a WeakKeyDictionary
+        # populated lazily on first ``get_choices`` lookup. Force the dictionary to be
+        # populated now so the choices are bound to the instance (rather than only to
+        # the class) and survive a round-trip through ``__setgluestate__``.
+        VispyVolumeLayerState.cut_plane_color_mode.set_choices(self, ['Fixed', 'Linear'])

--- a/glue_vispy_viewers/volume/layer_state.py
+++ b/glue_vispy_viewers/volume/layer_state.py
@@ -1,5 +1,5 @@
 from echo import CallbackProperty, SelectionCallbackProperty
-
+from glue.config import colormaps
 from glue.viewers.volume3d.layer_state import VolumeLayerState3D as VolumeLayerState
 
 __all__ = ['VispyVolumeLayerState']
@@ -28,3 +28,9 @@ class VispyVolumeLayerState(VolumeLayerState):
         # populated now so the choices are bound to the instance (rather than only to
         # the class) and survive a round-trip through ``__setgluestate__``.
         VispyVolumeLayerState.cut_plane_color_mode.set_choices(self, ['Fixed', 'Linear'])
+
+        self.cut_plane_cmap = self.cmap
+
+    @property
+    def cut_plane_cmap_name(self):
+        return colormaps.name_from_cmap(self.cut_plane_cmap)

--- a/glue_vispy_viewers/volume/layer_state.py
+++ b/glue_vispy_viewers/volume/layer_state.py
@@ -1,11 +1,11 @@
 from echo import CallbackProperty, SelectionCallbackProperty
 from glue.config import colormaps
-from glue.viewers.volume3d.layer_state import VolumeLayerState3D as VolumeLayerState
+from glue.viewers.volume3d.layer_state import VolumeLayerState3D
 
-__all__ = ['VispyVolumeLayerState']
+__all__ = ['VolumeLayerState']
 
 
-class VispyVolumeLayerState(VolumeLayerState):
+class VolumeLayerState(VolumeLayerState3D):
     """Volume layer state with vispy-only extensions.
 
     Subclasses ``glue.viewers.volume3d.layer_state.VolumeLayerState``
@@ -27,7 +27,7 @@ class VispyVolumeLayerState(VolumeLayerState):
         # populated lazily on first ``get_choices`` lookup. Force the dictionary to be
         # populated now so the choices are bound to the instance (rather than only to
         # the class) and survive a round-trip through ``__setgluestate__``.
-        VispyVolumeLayerState.cut_plane_color_mode.set_choices(self, ['Fixed', 'Linear'])
+        VolumeLayerState.cut_plane_color_mode.set_choices(self, ['Fixed', 'Linear'])
 
         self.cut_plane_cmap = self.cmap
 

--- a/glue_vispy_viewers/volume/qt/cutting_plane_widget.ui
+++ b/glue_vispy_viewers/volume/qt/cutting_plane_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>276</width>
-    <height>220</height>
+    <height>247</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -57,10 +57,44 @@
       <property name="verticalSpacing">
        <number>4</number>
       </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_mode">
+      <item row="2" column="1">
+       <widget class="QSlider" name="value_cut_tilt">
+        <property name="maximum">
+         <number>180</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="QPushButton" name="button_flip_cut">
         <property name="text">
-         <string>Mode:</string>
+         <string>Flip shown/clipped side</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_depth">
+        <property name="text">
+         <string>Depth:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_image">
+        <property name="text">
+         <string>Image opacity:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSlider" name="value_cut_depth">
+        <property name="maximum">
+         <number>1000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
@@ -74,10 +108,51 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_mode">
+        <property name="text">
+         <string>Mode:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_tilt">
+        <property name="text">
+         <string>Tilt:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QSlider" name="value_cut_plane_image_opacity">
+        <property name="maximum">
+         <number>1000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSlider" name="value_cut_rotation">
+        <property name="maximum">
+         <number>360</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_axis">
         <property name="text">
          <string>Axis:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_rotation">
+        <property name="text">
+         <string>Rotation:</string>
         </property>
        </widget>
       </item>
@@ -133,78 +208,17 @@
         </layout>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_tilt">
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_color">
         <property name="text">
-         <string>Tilt:</string>
+         <string>Image background:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QSlider" name="value_cut_tilt">
-        <property name="maximum">
-         <number>180</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_rotation">
+      <item row="6" column="1">
+       <widget class="QColorBox" name="color_cut_plane_image_bgcolor">
         <property name="text">
-         <string>Rotation:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QSlider" name="value_cut_rotation">
-        <property name="maximum">
-         <number>360</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_depth">
-        <property name="text">
-         <string>Depth:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QSlider" name="value_cut_depth">
-        <property name="maximum">
-         <number>1000</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_image">
-        <property name="text">
-         <string>Image opacity:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QSlider" name="value_cut_plane_image_opacity">
-        <property name="maximum">
-         <number>1000</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QPushButton" name="button_flip_cut">
-        <property name="text">
-         <string>Flip shown/clipped side</string>
+         <string/>
         </property>
        </widget>
       </item>
@@ -226,6 +240,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QColorBox</class>
+   <extends>QLabel</extends>
+   <header>glue_qt.utils.colors</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.py
@@ -79,6 +79,7 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
         if cut_enabled:
             self.ui.label_cut_plane_color_mode.show()
             self.ui.combotext_cut_plane_color_mode.show()
+            self.ui.label_cutting_plane.show()
             if self.state.cut_plane_color_mode == "Fixed":
                 self.ui.label_cut_plane_color.show()
                 self.ui.color_cut_plane_color.show()
@@ -90,6 +91,7 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
                 self.ui.label_cut_plane_cmap.show()
                 self.ui.combodata_cut_plane_cmap.show()
         else:
+            self.ui.label_cutting_plane.hide()
             self.ui.label_cut_plane_color_mode.hide()
             self.ui.combotext_cut_plane_color_mode.hide()
             self.ui.label_cut_plane_color.hide()

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.py
@@ -98,4 +98,3 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
             self.ui.color_cut_plane_color.hide()
             self.ui.label_cut_plane_cmap.hide()
             self.ui.combodata_cut_plane_cmap.hide()
-

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.py
@@ -28,7 +28,11 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
         self.layer = layer_artist.layer
 
         self._update_color_mode()
+        self._update_cut_plane()
         self.state.add_callback('color_mode', self._update_color_mode)
+        if hasattr(self.layer_artist._viewer_state, 'cut_enabled'):
+            self.layer_artist._viewer_state.add_callback('cut_enabled', self._update_cut_plane)
+            self.state.add_callback('cut_plane_color_mode', self._update_cut_plane)
 
         # autoconnect needs to come after setting up the component IDs
         connect_kwargs = {'value_alpha': dict(value_range=(0., 1.))}
@@ -69,3 +73,27 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
             self.ui.color_color.hide()
             self.ui.label_cmap.show()
             self.ui.combodata_cmap.show()
+
+    def _update_cut_plane(self, *args):
+        cut_enabled = getattr(self.layer_artist._viewer_state, 'cut_enabled', False)
+        if cut_enabled:
+            self.ui.label_cut_plane_color_mode.show()
+            self.ui.combotext_cut_plane_color_mode.show()
+            if self.state.cut_plane_color_mode == "Fixed":
+                self.ui.label_cut_plane_color.show()
+                self.ui.color_cut_plane_color.show()
+                self.ui.label_cut_plane_cmap.hide()
+                self.ui.combodata_cut_plane_cmap.hide()
+            else:
+                self.ui.label_cut_plane_color.hide()
+                self.ui.color_cut_plane_color.hide()
+                self.ui.label_cut_plane_cmap.show()
+                self.ui.combodata_cut_plane_cmap.show()
+        else:
+            self.ui.label_cut_plane_color_mode.hide()
+            self.ui.combotext_cut_plane_color_mode.hide()
+            self.ui.label_cut_plane_color.hide()
+            self.ui.color_cut_plane_color.hide()
+            self.ui.label_cut_plane_cmap.hide()
+            self.ui.combodata_cut_plane_cmap.hide()
+

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -17,21 +17,14 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <item row="11" column="0">
+   <item row="12" column="0">
     <widget class="QLabel" name="label_cut_plane_color">
      <property name="text">
-      <string>Cut plane color:</string>
+      <string>Color:</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
-    <widget class="QRadioButton" name="radio_subset_data">
-     <property name="text">
-      <string>Data</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="1">
+   <item row="15" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Vertical</enum>
@@ -44,43 +37,6 @@
      </property>
     </spacer>
    </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QColormapCombo" name="combodata_cmap"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_limits">
-     <property name="text">
-      <string>Limits:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="label_cut_plane_cmap">
-     <property name="text">
-      <string>Cut plane colormap:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QColorBox" name="color_color">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="1" colspan="2">
-    <widget class="QColorBox" name="color_cut_plane_color">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_att">
      <property name="text">
@@ -88,47 +44,13 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="combosel_attribute">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_color_mode">
-     <property name="text">
-      <string>Color mode:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="1" colspan="2">
-    <widget class="QColormapCombo" name="combodata_cut_plane_cmap"/>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_cmap">
-     <property name="text">
-      <string>Colormap:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_subset_mode">
-     <property name="text">
-      <string>Subset:</string>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="1" colspan="2">
     <widget class="QComboBox" name="combosel_stretch"/>
    </item>
-   <item row="1" column="2" alignment="Qt::AlignmentFlag::AlignLeft">
-    <widget class="QLineEdit" name="valuetext_v_max"/>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_color">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_limits">
      <property name="text">
-      <string>Color:</string>
+      <string>Limits:</string>
      </property>
     </widget>
    </item>
@@ -141,6 +63,78 @@
       <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
+   </item>
+   <item row="9" column="2">
+    <widget class="QRadioButton" name="radio_subset_outline">
+     <property name="text">
+      <string>Outline</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1" colspan="2">
+    <widget class="QComboBox" name="combotext_cut_plane_color_mode">
+     <item>
+      <property name="text">
+       <string>Fixed</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Linear</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QRadioButton" name="radio_subset_data">
+     <property name="text">
+      <string>Data</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_color_mode">
+     <property name="text">
+      <string>Color mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="valuetext_v_min"/>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_cut_plane_cmap">
+     <property name="text">
+      <string>Colormap:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_stretch">
+     <property name="text">
+      <string>Stretch</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2" alignment="Qt::AlignmentFlag::AlignLeft">
+    <widget class="QLineEdit" name="valuetext_v_max"/>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="combosel_attribute">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1" colspan="2">
+    <widget class="QColorBox" name="color_cut_plane_color">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1" colspan="2">
+    <widget class="QColormapCombo" name="combodata_cut_plane_cmap"/>
    </item>
    <item row="3" column="1" colspan="2">
     <widget class="QComboBox" name="combotext_color_mode">
@@ -162,42 +156,55 @@
      </item>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_stretch">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_cmap">
      <property name="text">
-      <string>Stretch</string>
+      <string>Colormap:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="valuetext_v_min"/>
-   </item>
-   <item row="9" column="2">
-    <widget class="QRadioButton" name="radio_subset_outline">
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_cut_plane_color_mode">
      <property name="text">
-      <string>Outline</string>
+      <string>Color mode</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_color">
+     <property name="text">
+      <string>Color:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_subset_mode">
+     <property name="text">
+      <string>Subset:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="2">
+    <widget class="QColormapCombo" name="combodata_cmap"/>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QColorBox" name="color_color">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
      </property>
     </widget>
    </item>
    <item row="10" column="0">
-    <widget class="QLabel" name="label_cut_plane_color_mode">
+    <widget class="QLabel" name="label_cutting_plane">
      <property name="text">
-      <string>Cut plane mode:</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Cutting Plane&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-    </widget>
-   </item>
-   <item row="10" column="1" colspan="2">
-    <widget class="QComboBox" name="combotext_cut_plane_color_mode">
-     <item>
-      <property name="text">
-       <string>Fixed</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Linear</string>
-      </property>
-     </item>
     </widget>
    </item>
   </layout>

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>292</width>
-    <height>246</height>
+    <width>296</width>
+    <height>343</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,10 +17,128 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <item row="9" column="2">
-    <widget class="QRadioButton" name="radio_subset_outline">
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_cut_plane_color">
      <property name="text">
-      <string>Outline</string>
+      <string>Cut plane color:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QRadioButton" name="radio_subset_data">
+     <property name="text">
+      <string>Data</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="1" colspan="2">
+    <widget class="QColormapCombo" name="combodata_cmap"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_limits">
+     <property name="text">
+      <string>Limits:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_cut_plane_cmap">
+     <property name="text">
+      <string>Cut plane colormap:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QColorBox" name="color_color">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1" colspan="2">
+    <widget class="QColorBox" name="color_cut_plane_color">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_att">
+     <property name="text">
+      <string>Attribute:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="combosel_attribute">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_color_mode">
+     <property name="text">
+      <string>Color mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1" colspan="2">
+    <widget class="QColormapCombo" name="combodata_cut_plane_cmap"/>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_cmap">
+     <property name="text">
+      <string>Colormap:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_subset_mode">
+     <property name="text">
+      <string>Subset:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="2">
+    <widget class="QComboBox" name="combosel_stretch"/>
+   </item>
+   <item row="1" column="2" alignment="Qt::AlignmentFlag::AlignLeft">
+    <widget class="QLineEdit" name="valuetext_v_max"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_color">
+     <property name="text">
+      <string>Color:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="3">
+    <widget class="QSlider" name="value_alpha">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -44,107 +162,6 @@
      </item>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_color">
-     <property name="text">
-      <string>Color:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_att">
-     <property name="text">
-      <string>Attribute:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="3">
-    <widget class="QSlider" name="value_alpha">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QRadioButton" name="radio_subset_data">
-     <property name="text">
-      <string>Data</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_limits">
-     <property name="text">
-      <string>Limits:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_subset_mode">
-     <property name="text">
-      <string>Subset:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_cmap">
-     <property name="text">
-      <string>Colormap:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_color_mode">
-     <property name="text">
-      <string>Color mode:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="2">
-    <widget class="QComboBox" name="combosel_stretch"/>
-   </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QColorBox" name="color_color">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="valuetext_v_min"/>
-   </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QColormapCombo" name="combodata_cmap"/>
-   </item>
-   <item row="10" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="combosel_attribute">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="0">
     <widget class="QLabel" name="label_stretch">
      <property name="text">
@@ -152,8 +169,36 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2" alignment="Qt::AlignLeft">
-    <widget class="QLineEdit" name="valuetext_v_max"/>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="valuetext_v_min"/>
+   </item>
+   <item row="9" column="2">
+    <widget class="QRadioButton" name="radio_subset_outline">
+     <property name="text">
+      <string>Outline</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_cut_plane_color_mode">
+     <property name="text">
+      <string>Cut plane mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1" colspan="2">
+    <widget class="QComboBox" name="combotext_cut_plane_color_mode">
+     <item>
+      <property name="text">
+       <string>Fixed</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Linear</string>
+      </property>
+     </item>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -387,7 +387,7 @@ def get_frag_shader(volumes, clipped=False, n_volume_max=5):
         # into the rest" knob meant for the volume render; the slice already
         # has the user's opacity slider for that, and pulling u_weight in
         # would dim Linear-mode slices.
-        plane_sample += "plane_color = $plane_cmap{0:d}(plane_val);\n".format(index)
+        plane_sample += "plane_color = $cut_plane_cmap{0:d}(plane_val);\n".format(index)
         # Unlike the volume MIP pass, the slice image should appear across the
         # whole cut surface, not only where the colormap alpha (i.e. the volume
         # opacity) is non-zero. Count every in-bounds sample and average the

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -94,6 +94,8 @@ uniform float u_cutting_plane_d;
 // the visible face of the remaining volume rather than hiding behind it.
 uniform float u_cut_plane_image_opacity;
 
+uniform vec4 u_cut_plane_image_bgcolor;
+
 // uniforms for lighting. Hard coded until we figure out how to do lights
 const vec4 u_ambient = vec4(0.2, 0.4, 0.2, 1.0);
 const vec4 u_diffuse = vec4(0.8, 0.2, 0.2, 1.0);
@@ -266,7 +268,7 @@ void main() {{
     // over the MIP result at the user-controlled opacity.
     if (u_cut_plane_image_opacity > 0.0 && plane_image_visible == 1) {{
         vec3 plane_loc = (v_position + view_ray * plane_t) / u_shape;
-        vec4 plane_total_color = vec4(0., 0., 0., 0.);
+        vec4 plane_total_color = u_cut_plane_image_bgcolor;
         vec4 plane_color = vec4(0., 0., 0., 0.);
         float plane_count = 0.;
         float plane_val;
@@ -391,7 +393,7 @@ def get_frag_shader(volumes, clipped=False, n_volume_max=5):
         # opacity) is non-zero. Count every in-bounds sample and average the
         # colourmap colours directly so values at or below v_min still render
         # (as dark pixels via the premultiply) instead of leaving holes.
-        plane_sample += "plane_total_color += plane_color;\n"
+        plane_sample += "plane_total_color.rgb = mix(plane_total_color.rgb, plane_color.rgb, plane_color.a);\n"
         plane_sample += "plane_count += 1.0;\n\n"
         if clipped:
             plane_sample += "}\n\n"

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -387,7 +387,7 @@ def get_frag_shader(volumes, clipped=False, n_volume_max=5):
         # into the rest" knob meant for the volume render; the slice already
         # has the user's opacity slider for that, and pulling u_weight in
         # would dim Linear-mode slices.
-        plane_sample += "plane_color = $cmap{0:d}(plane_val);\n".format(index)
+        plane_sample += "plane_color = $plane_cmap{0:d}(plane_val);\n".format(index)
         # Unlike the volume MIP pass, the slice image should appear across the
         # whole cut surface, not only where the colormap alpha (i.e. the volume
         # opacity) is non-zero. Count every in-bounds sample and average the

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -393,7 +393,8 @@ def get_frag_shader(volumes, clipped=False, n_volume_max=5):
         # opacity) is non-zero. Count every in-bounds sample and average the
         # colourmap colours directly so values at or below v_min still render
         # (as dark pixels via the premultiply) instead of leaving holes.
-        plane_sample += "plane_total_color.rgb = mix(plane_total_color.rgb, plane_color.rgb, plane_color.a);\n"
+        plane_sample += ("plane_total_color.rgb = "
+                         "mix(plane_total_color.rgb, plane_color.rgb, plane_color.a);\n")
         plane_sample += "plane_count += 1.0;\n\n"
         if clipped:
             plane_sample += "}\n\n"

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -263,9 +263,8 @@ void main() {{
     }}
 
     // Cut-surface image overlay. Samples each layer once at the plane intersection,
-    // colormaps it through the layer's own colormap function (so colormap, v_min,
-    // v_max and subset multiply are reused for free), then composites the result
-    // over the MIP result at the user-controlled opacity.
+    // colormaps it through the layer's cutting plane colormap function,
+    // then composites the result over the MIP result at the user-controlled opacity.
     if (u_cut_plane_image_opacity > 0.0 && plane_image_visible == 1) {{
         vec3 plane_loc = (v_position + view_ray * plane_t) / u_shape;
         vec4 plane_total_color = u_cut_plane_image_bgcolor;

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -167,6 +167,9 @@ class Vispy3DVolumeViewerState(VolumeViewerState3D):
         False, docstring='Whether to show the opposite side of the cutting plane.')
     cut_plane_image_opacity = CallbackProperty(
         0.0, docstring='Opacity of the slice image rendered on the cutting plane (0 = off).')
+    cut_plane_image_bgcolor = CallbackProperty(
+        "#000000", docstring='Base color of the cutting plane')
+
 
     def flip_cut(self):
         """Swap which side of the cutting plane is shown versus clipped.

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -170,7 +170,6 @@ class Vispy3DVolumeViewerState(VolumeViewerState3D):
     cut_plane_image_bgcolor = CallbackProperty(
         "#000000", docstring='Base color of the cutting plane')
 
-
     def flip_cut(self):
         """Swap which side of the cutting plane is shown versus clipped.
 

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -71,6 +71,7 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
                      'x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max'):
             self.state.add_callback(attr, self._update_cutting_plane)
         self.state.add_callback('cut_plane_image_opacity', self._update_cut_plane_image_opacity)
+        self.state.add_callback('cut_plane_image_bgcolor', self._update_cut_plane_image_bgcolor)
         self._update_cutting_plane()
         self._update_cut_plane_image_opacity()
 
@@ -85,6 +86,10 @@ class VispyVolumeViewerMixin(BaseVispyViewerMixin):
         # orientation flips so the cutting plane stays consistent right away.
         for attr in ('x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max'):
             self.state.add_callback(attr, self._resample_on_axis_flip)
+
+    def _update_cut_plane_image_bgcolor(self, *args):
+        self._vispy_widget._multivol.set_cut_plane_image_bgcolor(self.state.cut_plane_image_bgcolor)
+        self._vispy_widget.canvas.update()
 
     def _resample_on_axis_flip(self, *args):
         bounds = self._vispy_widget._multivol._data_bounds

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -280,7 +280,7 @@ class MultiVolumeVisual(VolumeVisual):
             cmap = get_colormap(cmap)
         self.volumes[label]['cut_plane_cmap'] = cmap
         index = self.volumes[label]['index']
-        self.shared_program.frag['plane_cmap{0:d}'.format(index)] = Function(cmap.glsl_map)
+        self.shared_program.frag['cut_plane_cmap{0:d}'.format(index)] = Function(cmap.glsl_map)
 
     def set_weight(self, label, weight):
         index = self.volumes[label]['index']

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -275,6 +275,13 @@ class MultiVolumeVisual(VolumeVisual):
         if 'data' in self.volumes[label]:
             self._update_scaled_data(label)
 
+    def set_cut_plane_cmap(self, label, cmap):
+        if isinstance(cmap, str):
+            cmap = get_colormap(cmap)
+        self.volumes[label]['cut_plane_cmap'] = cmap
+        index = self.volumes[label]['index']
+        self.shared_program.frag['plane_cmap{0:d}'.format(index)] = Function(cmap.glsl_map)
+
     def set_weight(self, label, weight):
         index = self.volumes[label]['index']
         self.shared_program['u_weight_{0:d}'.format(index)] = weight

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -232,8 +232,6 @@ class MultiVolumeVisual(VolumeVisual):
         self.shared_program['u_cut_plane_image_opacity'] = float(opacity)
 
     def set_cut_plane_image_bgcolor(self, color):
-        print("Setting cut plane bgcolor")
-        print(Color(color).rgba)
         self.shared_program['u_cut_plane_image_bgcolor'] = Color(color).rgba
 
     # The following methods don't require any changes to the shader code, so we

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -104,6 +104,7 @@ class MultiVolumeVisual(VolumeVisual):
         # Set initial cutting plane and slice-image overlay
         self.set_cutting_plane(None)
         self.set_cut_plane_image_opacity(0.0)
+        self.set_cut_plane_image_bgcolor(Color("black").rgba)
 
         # Set up texture vertices - note that these variables are required by
         # the parent VolumeVisual class.
@@ -229,6 +230,11 @@ class MultiVolumeVisual(VolumeVisual):
 
     def set_cut_plane_image_opacity(self, opacity):
         self.shared_program['u_cut_plane_image_opacity'] = float(opacity)
+
+    def set_cut_plane_image_bgcolor(self, color):
+        print("Setting cut plane bgcolor")
+        print(Color(color).rgba)
+        self.shared_program['u_cut_plane_image_bgcolor'] = Color(color).rgba
 
     # The following methods don't require any changes to the shader code, so we
     # don't update the shader after setting the OpenGL variables.


### PR DESCRIPTION
This PR is an attempt to implement the functionality discussed in yesterday's glue meeting - allowing the display of a layer on the cutting plane to differ from its display in the primary volume. This allows setting the color mode (fixed/linear) and color/colormap separately from the standard volume settings; the stretch is shared between the two. Note that this is built on top of #410. At the shader level, the difference (other than the changes from #410) is that we sample the specific cut plane colormap at the plane value, rather than the regular colormap.

@astrofrog I ran into one issue implementing this, which is that I'm not sure how to get the value of `cut_enabled` from the viewer state in the layer widget. For the Qt widget there's no problem since we pass in the layer artist (which has a reference to the viewer state), but we construct the Jupyter widget using the layer state which does not (it has a `viewer_state` member, but its value is `None`).
